### PR TITLE
Add files needed to publish frugalos binary to Docker Hub

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,0 +1,17 @@
+# STAGE-1: Build frugalos binary
+FROM rust:1.30.0-slim
+
+ARG FRUGALOS_VERSION
+
+RUN apt update
+RUN apt install -y gcc automake libtool git make patch curl
+
+RUN cargo install frugalos --version $FRUGALOS_VERSION
+
+
+# STAGE-2: Copy the built binary
+FROM debian
+
+COPY --from=0 /usr/local/cargo/bin/frugalos /bin/frugalos
+ENTRYPOINT ["/bin/frugalos"]
+CMD ["--help"]

--- a/docker/hub/README.md
+++ b/docker/hub/README.md
@@ -1,0 +1,4 @@
+Dockerfile for Docker Hub
+==========================
+
+See [Publish To Docker Hub](https://github.com/frugalos/frugalos/wiki/Publish-to-Docker-Hub) for details.

--- a/docker/hub/publish.sh
+++ b/docker/hub/publish.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Publish the frugalos binary of the specified version to Docker Hub.
+#
+# Usage: publish.sh $FRUGALOS_VERSION
+
+set -eux
+
+FRUGALOS_VERSION=$1
+
+docker build --build-arg FRUGALOS_VERSION=$FRUGALOS_VERSION -t frugalos/frugalos:${FRUGALOS_VERSION} .
+docker push frugalos/frugalos:${FRUGALOS_VERSION}


### PR DESCRIPTION
Usage example:
```console
// Publish
$ ./publish.sh 0.9.0

// Run
$ docker run -it --rm frugalos/frugalos:0.9.0
frugalos 0.9.0

USAGE:
    frugalos [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -l, --loglevel <LOGLEVEL>                           [default: info]  [possible values: debug, info, warning]
        --max_concurrent_logs <MAX_CONCURRENT_LOGS>     [default: 4096]

SUBCOMMANDS:
    create
    help             Prints this message or the help of the given subcommand(s)
    join
    leave
    start
    stop
    take-snapshot
```