### PR TITLE
allow failures for the beta channel on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 
 matrix:
   allow_failures:
+    - rust: beta
     - rust: nightly
 
 env:


### PR DESCRIPTION
Add the beta channel to `allow_failures` in the same way as the following:

- https://github.com/frugalos/liberasurecode/pull/1/commits/3754dec339d4b2b1710e0097578544a9175ec1bd
- https://github.com/frugalos/cannyls/commit/ab731dc9f9cd2e6b447d3a8b93245f80b064c02d