### PR TITLE
Support default-put-content-timeout and minimum-put-content-timeout options for `start` sub-command.

### DIFF
--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -173,7 +173,7 @@ impl MdsClient {
         let put_content_timeout = Seconds(if let Deadline::Within(d) = deadline {
             d.as_secs() + self.client_config.minimum_put_content_timeout.0
         } else {
-            self.client_config.default_put_content_timeout.0
+            self.client_config.minimum_put_content_timeout.0
         });
         Request::new(self.clone(), parent, move |client| {
             Box::new(

--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -18,7 +18,7 @@ use std::ops::Range;
 use std::sync::{Arc, Mutex};
 use trackable::error::ErrorKindExt;
 
-use config::ClusterConfig;
+use config::{ClusterConfig, MdsClientConfig};
 use {Error, ErrorKind, ObjectValue, Result};
 
 #[derive(Debug, Clone)]
@@ -26,15 +26,22 @@ pub struct MdsClient {
     logger: Logger,
     rpc_service: RpcServiceHandle,
     inner: Arc<Mutex<Inner>>,
+    client_config: MdsClientConfig,
 }
 impl MdsClient {
-    pub fn new(logger: Logger, rpc_service: RpcServiceHandle, config: ClusterConfig) -> Self {
+    pub fn new(
+        logger: Logger,
+        rpc_service: RpcServiceHandle,
+        cluster_config: ClusterConfig,
+        client_config: MdsClientConfig,
+    ) -> Self {
         // TODO: 以下のassertionは復活させたい
         // assert!(!config.members.is_empty());
         MdsClient {
             logger,
             rpc_service,
-            inner: Arc::new(Mutex::new(Inner::new(config))),
+            inner: Arc::new(Mutex::new(Inner::new(cluster_config))),
+            client_config,
         }
     }
 
@@ -164,9 +171,9 @@ impl MdsClient {
     ) -> impl Future<Item = (ObjectVersion, bool), Error = Error> {
         debug!(self.logger, "Starts PUT: id={:?}", id);
         let put_content_timeout = Seconds(if let Deadline::Within(d) = deadline {
-            d.as_secs() + 60 // XXX: hard-coding
+            d.as_secs() + self.client_config.minimum_put_content_timeout.0
         } else {
-            60
+            self.client_config.default_put_content_timeout.0
         });
         Request::new(self.clone(), parent, move |client| {
             Box::new(

--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -171,9 +171,9 @@ impl MdsClient {
     ) -> impl Future<Item = (ObjectVersion, bool), Error = Error> {
         debug!(self.logger, "Starts PUT: id={:?}", id);
         let put_content_timeout = Seconds(if let Deadline::Within(d) = deadline {
-            d.as_secs() + self.client_config.minimum_put_content_timeout.0
+            d.as_secs() + self.client_config.put_content_timeout.0
         } else {
-            self.client_config.minimum_put_content_timeout.0
+            self.client_config.put_content_timeout.0
         });
         Request::new(self.clone(), parent, move |client| {
             Box::new(

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -33,7 +33,12 @@ impl Client {
         config: ClientConfig,
         ec: Option<ErasureCoder>,
     ) -> Self {
-        let mds = MdsClient::new(logger.clone(), rpc_service.clone(), config.cluster.clone());
+        let mds = MdsClient::new(
+            logger.clone(),
+            rpc_service.clone(),
+            config.cluster.clone(),
+            config.mds.clone(),
+        );
         let storage = StorageClient::new(logger, config, rpc_service, ec);
         Client { mds, storage }
     }

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -41,15 +41,15 @@ pub(crate) fn make_lump_id(node: &NodeId, version: ObjectVersion) -> LumpId {
 /// Configuration for `MdsClient`.
 #[derive(Debug, Clone)]
 pub struct MdsClientConfig {
-    /// Timeout in seconds, which is added to `Deadline::Within`.
-    pub minimum_put_content_timeout: Seconds,
+    /// Timeout in seconds, which is used to determine an actual `Deadline` on putting a content.
+    pub put_content_timeout: Seconds,
 }
 
 impl Default for MdsClientConfig {
     fn default() -> Self {
         MdsClientConfig {
             // This default value is a heuristic.
-            minimum_put_content_timeout: Seconds(60),
+            put_content_timeout: Seconds(60),
         }
     }
 }

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -41,9 +41,6 @@ pub(crate) fn make_lump_id(node: &NodeId, version: ObjectVersion) -> LumpId {
 /// Configuration for `MdsClient`.
 #[derive(Debug, Clone)]
 pub struct MdsClientConfig {
-    /// Timeout in seconds, which is default if `Deadline` is not specified.
-    pub default_put_content_timeout: Seconds,
-
     /// Timeout in seconds, which is added to `Deadline::Within`.
     pub minimum_put_content_timeout: Seconds,
 }
@@ -51,8 +48,7 @@ pub struct MdsClientConfig {
 impl Default for MdsClientConfig {
     fn default() -> Self {
         MdsClientConfig {
-            // These default values are heuristic.
-            default_put_content_timeout: Seconds(60),
+            // This default value is a heuristic.
             minimum_put_content_timeout: Seconds(60),
         }
     }

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -3,6 +3,7 @@ use byteorder::{BigEndian, ByteOrder};
 use cannyls::lump::LumpId;
 use frugalos_raft::NodeId;
 use libfrugalos::entity::object::ObjectVersion;
+use libfrugalos::time::Seconds;
 use raftlog::cluster::ClusterMembers;
 use siphasher::sip::SipHasher;
 use std::hash::{Hash, Hasher};
@@ -37,13 +38,34 @@ pub(crate) fn make_lump_id(node: &NodeId, version: ObjectVersion) -> LumpId {
     LumpId::new(BigEndian::read_u128(&id[..]))
 }
 
+/// Configuration for `MdsClient`.
+#[derive(Debug, Clone)]
+pub struct MdsClientConfig {
+    /// Timeout in seconds, which is default if `Deadline` is not specified.
+    pub default_put_content_timeout: Seconds,
+
+    /// Timeout in seconds, which is added to `Deadline::Within`.
+    pub minimum_put_content_timeout: Seconds,
+}
+
+impl Default for MdsClientConfig {
+    fn default() -> Self {
+        MdsClientConfig {
+            // These default values are heuristic.
+            default_put_content_timeout: Seconds(60),
+            minimum_put_content_timeout: Seconds(60),
+        }
+    }
+}
+
 // FIXME: rename
 /// クライアントがセグメントにアクセスする際に使用する構成情報。
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ClientConfig {
     pub cluster: ClusterConfig,
     pub storage: Storage,
+    pub mds: MdsClientConfig,
 }
 impl ClientConfig {
     /// 対象のセグメントに属しているメンバ一覧を返す。

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -199,6 +199,7 @@ pub mod tests {
                 ClientConfig {
                     cluster: self.cluster_config.clone(),
                     storage: self.make_dispersed_storage(),
+                    mds: MdsClientConfig::default(),
                 },
                 None,
             )
@@ -222,6 +223,7 @@ pub mod tests {
                 ClientConfig {
                     cluster: self.cluster_config.clone(),
                     storage: self.make_dispersed_storage(),
+                    mds: MdsClientConfig::default(),
                 },
                 self.rpc_service_handle.clone(),
                 None,

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
-use frugalos_segment::config::ClusterMember;
+use frugalos_segment::config::{ClusterMember, MdsClientConfig};
 use frugalos_segment::Client as Segment;
 use frugalos_segment::{self, ErasureCoder};
 use libfrugalos::entity::bucket::Bucket as BucketConfig;
@@ -15,10 +15,16 @@ pub struct Bucket {
     rpc_service: RpcServiceHandle,
     ec: Option<ErasureCoder>,
     storage_config: frugalos_segment::config::Storage,
+    mds_client_config: MdsClientConfig,
     segments: Vec<Segment>,
 }
 impl Bucket {
-    pub fn new(logger: Logger, rpc_service: RpcServiceHandle, config: &BucketConfig) -> Self {
+    pub fn new(
+        logger: Logger,
+        rpc_service: RpcServiceHandle,
+        config: &BucketConfig,
+        mds_client_config: MdsClientConfig,
+    ) -> Self {
         let ec = match config {
             BucketConfig::Metadata(_) => None,
             BucketConfig::Replicated(_) => None,
@@ -50,6 +56,7 @@ impl Bucket {
                 members: Vec::new(),
             },
             storage: storage_config.clone(),
+            mds: mds_client_config.clone(),
         };
         let segment = Segment::new(
             logger.clone(),
@@ -66,12 +73,14 @@ impl Bucket {
             ec,
             storage_config,
             segments,
+            mds_client_config,
         }
     }
     pub fn update_segment(&mut self, segment_no: u16, members: Vec<ClusterMember>) {
         let segment_config = frugalos_segment::config::ClientConfig {
             cluster: frugalos_segment::config::ClusterConfig { members },
             storage: self.storage_config.clone(),
+            mds: self.mds_client_config.clone(),
         };
         let segment = Segment::new(
             self.logger.clone(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 use trackable::error::ErrorKindExt;
 
 use config_server::ConfigServer;
+use frugalos_segment;
 use rpc_server::RpcServer;
 use server::{spawn_report_spans_thread, Server};
 use service;
@@ -42,6 +43,9 @@ pub struct FrugalosDaemonBuilder {
 
     /// Jaegerのトレースのサンプリング確率。
     pub sampling_rate: f64,
+
+    /// `MdsClient` に与える Configuration。
+    pub mds_client_config: frugalos_segment::config::MdsClientConfig,
 }
 impl FrugalosDaemonBuilder {
     /// 新しい`FrugalosDaemonBuilder`インスタンスを生成する。
@@ -50,6 +54,7 @@ impl FrugalosDaemonBuilder {
             logger,
             executor_threads: num_cpus::get(),
             sampling_rate: 0.001,
+            mds_client_config: Default::default(),
         }
     }
 
@@ -118,6 +123,7 @@ impl FrugalosDaemon {
             config_service,
             &mut rpc_server_builder,
             rpc_service.handle(),
+            builder.mds_client_config.clone(),
         ))?;
 
         let sampler = Sampler::<SpanContextState>::or(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate clap;
 extern crate frugalos;
 extern crate frugalos_config;
+extern crate frugalos_segment;
 extern crate hostname;
 extern crate libfrugalos;
 #[macro_use]
@@ -11,10 +12,14 @@ extern crate trackable;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use libfrugalos::entity::server::Server;
+use libfrugalos::time::Seconds;
 use sloggers::Build;
 use std::env;
 use std::net::{SocketAddr, ToSocketAddrs};
 use trackable::error::Failure;
+
+use frugalos::{Error, Result};
+use frugalos_segment::config::MdsClientConfig;
 
 #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
 fn main() {
@@ -51,7 +56,9 @@ fn main() {
                         .long("http-server-bind-addr")
                         .takes_value(true)
                         .default_value("0.0.0.0:3000"),
-                ).arg(data_dir_arg()),
+                ).arg(data_dir_arg())
+                .arg(default_put_content_timeout_arg())
+                .arg(minimum_put_content_timeout_arg()),
         ).subcommand(
             SubCommand::with_name("stop").arg(
                 Arg::with_name("RPC_ADDR")
@@ -175,6 +182,8 @@ fn main() {
             matches.value_of("SAMPLING_RATE").unwrap().parse()
         ));
         daemon.sampling_rate = sampling_rate;
+        daemon.mds_client_config =
+            track_try_unwrap!(track_any_err!(get_mds_client_config(&matches)));
 
         if let Some(threads) = matches.value_of("EXECUTOR_THREADS") {
             let threads: usize = track_try_unwrap!(track_any_err!(threads.parse()));
@@ -248,6 +257,22 @@ fn data_dir_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
 }
 
+fn default_put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("DEFAULT_PUT_CONTENT_TIMEOUT")
+        .help("Sets the default timeout in seconds on putting a content.")
+        .long("default-put-content-timeout")
+        .takes_value(true)
+        .default_value("60")
+}
+
+fn minimum_put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("MINIMUM_PUT_CONTENT_TIMEOUT")
+        .help("Sets the minimum timeout in seconds on putting a content.")
+        .long("minimum-put-content-timeout")
+        .takes_value(true)
+        .default_value("60")
+}
+
 fn get_data_dir(matches: &ArgMatches) -> String {
     if let Some(value) = matches
         .value_of("DATA_DIR")
@@ -261,4 +286,30 @@ fn get_data_dir(matches: &ArgMatches) -> String {
         );
         std::process::exit(1);
     }
+}
+
+/// Gets `MdsClientConfig` from CLI arguments.
+fn get_mds_client_config(matches: &ArgMatches) -> Result<MdsClientConfig> {
+    let mut config = MdsClientConfig::default();
+    config.default_put_content_timeout = matches
+        .value_of("DEFAULT_PUT_CONTENT_TIMEOUT")
+        .map_or_else(
+            || Ok(config.default_put_content_timeout),
+            |v| {
+                v.parse::<u64>()
+                    .map(Seconds)
+                    .map_err(|e| track!(Error::from(e)))
+            },
+        )?;
+    config.minimum_put_content_timeout = matches
+        .value_of("MINIMUM_PUT_CONTENT_TIMEOUT")
+        .map_or_else(
+            || Ok(config.minimum_put_content_timeout),
+            |v| {
+                v.parse::<u64>()
+                    .map(Seconds)
+                    .map_err(|e| track!(Error::from(e)))
+            },
+        )?;
+    Ok(config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ fn main() {
                         .takes_value(true)
                         .default_value("0.0.0.0:3000"),
                 ).arg(data_dir_arg())
-                .arg(default_put_content_timeout_arg())
                 .arg(minimum_put_content_timeout_arg()),
         ).subcommand(
             SubCommand::with_name("stop").arg(
@@ -257,14 +256,6 @@ fn data_dir_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
 }
 
-fn default_put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name("DEFAULT_PUT_CONTENT_TIMEOUT")
-        .help("Sets the default timeout in seconds on putting a content.")
-        .long("default-put-content-timeout")
-        .takes_value(true)
-        .default_value("60")
-}
-
 fn minimum_put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name("MINIMUM_PUT_CONTENT_TIMEOUT")
         .help("Sets the minimum timeout in seconds on putting a content.")
@@ -291,16 +282,6 @@ fn get_data_dir(matches: &ArgMatches) -> String {
 /// Gets `MdsClientConfig` from CLI arguments.
 fn get_mds_client_config(matches: &ArgMatches) -> Result<MdsClientConfig> {
     let mut config = MdsClientConfig::default();
-    config.default_put_content_timeout = matches
-        .value_of("DEFAULT_PUT_CONTENT_TIMEOUT")
-        .map_or_else(
-            || Ok(config.default_put_content_timeout),
-            |v| {
-                v.parse::<u64>()
-                    .map(Seconds)
-                    .map_err(|e| track!(Error::from(e)))
-            },
-        )?;
     config.minimum_put_content_timeout = matches
         .value_of("MINIMUM_PUT_CONTENT_TIMEOUT")
         .map_or_else(

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
                         .takes_value(true)
                         .default_value("0.0.0.0:3000"),
                 ).arg(data_dir_arg())
-                .arg(minimum_put_content_timeout_arg()),
+                .arg(put_content_timeout_arg()),
         ).subcommand(
             SubCommand::with_name("stop").arg(
                 Arg::with_name("RPC_ADDR")
@@ -256,10 +256,10 @@ fn data_dir_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
 }
 
-fn minimum_put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name("MINIMUM_PUT_CONTENT_TIMEOUT")
-        .help("Sets the minimum timeout in seconds on putting a content.")
-        .long("minimum-put-content-timeout")
+fn put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("PUT_CONTENT_TIMEOUT")
+        .help("Sets timeout in seconds on putting a content.")
+        .long("put-content-timeout")
         .takes_value(true)
         .default_value("60")
 }
@@ -282,15 +282,13 @@ fn get_data_dir(matches: &ArgMatches) -> String {
 /// Gets `MdsClientConfig` from CLI arguments.
 fn get_mds_client_config(matches: &ArgMatches) -> Result<MdsClientConfig> {
     let mut config = MdsClientConfig::default();
-    config.minimum_put_content_timeout = matches
-        .value_of("MINIMUM_PUT_CONTENT_TIMEOUT")
-        .map_or_else(
-            || Ok(config.minimum_put_content_timeout),
-            |v| {
-                v.parse::<u64>()
-                    .map(Seconds)
-                    .map_err(|e| track!(Error::from(e)))
-            },
-        )?;
+    config.put_content_timeout = matches.value_of("PUT_CONTENT_TIMEOUT").map_or_else(
+        || Ok(config.put_content_timeout),
+        |v| {
+            v.parse::<u64>()
+                .map(Seconds)
+                .map_err(|e| track!(Error::from(e)))
+        },
+    )?;
     Ok(config)
 }


### PR DESCRIPTION
Now users can set the minimum and default timeout in seconds when putting an object.

This PR resolves #39.