### PR TITLE
Revert "Bump version to 0.10.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos"
-version = "0.10.0"
+version = "0.9.0"
 authors = ["The FrugalOS Developers"]
 description = "Frugal Object Storage"
 homepage = "https://github.com/frugalos/frugalos"

--- a/frugalos_config/Cargo.toml
+++ b/frugalos_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_config"
-version = "0.3.1"
+version = "0.3.0"
 authors = ["The FrugalOS Developers"]
 description = "Configuration Management Layer of Frugalos"
 homepage = "https://github.com/frugalos/frugalos"

--- a/frugalos_mds/Cargo.toml
+++ b/frugalos_mds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_mds"
-version = "0.6.1"
+version = "0.6.0"
 authors = ["The FrugalOS Developers"]
 description = "Metadata Store for Frugalos"
 homepage = "https://github.com/frugalos/frugalos"

--- a/frugalos_raft/Cargo.toml
+++ b/frugalos_raft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_raft"
-version = "0.6.1"
+version = "0.6.0"
 authors = ["The FrugalOS Developers"]
 description = "An implementation of the `raftlog::Io` trait for `frugalos`"
 homepage = "https://github.com/frugalos/frugalos"

--- a/frugalos_segment/Cargo.toml
+++ b/frugalos_segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_segment"
-version = "0.5.1"
+version = "0.5.0"
 authors = ["The FrugalOS Developers"]
 description = "A segment in a bucket in a Frugalos cluster"
 homepage = "https://github.com/frugalos/frugalos"


### PR DESCRIPTION
Reverts frugalos/frugalos#60

This commit is incorrect because the version of `frugalos_segment` should be `0.6.*`.