### PR TITLE
Bump version to 0.10.0 (Revised)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "frugalos"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,9 +276,9 @@ dependencies = [
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_config 0.3.0",
- "frugalos_mds 0.6.0",
+ "frugalos_mds 0.6.1",
  "frugalos_raft 0.6.0",
- "frugalos_segment 0.5.0",
+ "frugalos_segment 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "frugalos_mds"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "frugalos_segment"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,7 +380,7 @@ dependencies = [
  "fibers 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "frugalos_mds 0.6.0",
+ "frugalos_mds 0.6.1",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["The FrugalOS Developers"]
 description = "Frugal Object Storage"
 homepage = "https://github.com/frugalos/frugalos"
@@ -26,7 +26,7 @@ fibers_tasque = "0.1"
 frugalos_config = { version = "0.3", path = "frugalos_config" }
 frugalos_mds = { version = "0.6", path = "frugalos_mds" }
 frugalos_raft = { version = "0.6", path = "frugalos_raft" }
-frugalos_segment = { version = "0.5", path = "frugalos_segment" }
+frugalos_segment = { version = "0.6", path = "frugalos_segment" }
 futures = "0.1"
 jemalloc-ctl = "0.2"
 hostname = "0.1"

--- a/frugalos_mds/Cargo.toml
+++ b/frugalos_mds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_mds"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The FrugalOS Developers"]
 description = "Metadata Store for Frugalos"
 homepage = "https://github.com/frugalos/frugalos"

--- a/frugalos_segment/Cargo.toml
+++ b/frugalos_segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos_segment"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The FrugalOS Developers"]
 description = "A segment in a bucket in a Frugalos cluster"
 homepage = "https://github.com/frugalos/frugalos"


### PR DESCRIPTION
Changes from https://github.com/frugalos/frugalos/pull/60:

* update `frugalos_segment` to `0.6.0`.
* use `frugalos_segment = "0.6.0"` in frugalos.