### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "frugalos"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frugalos"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The FrugalOS Developers"]
 description = "Frugal Object Storage"
 homepage = "https://github.com/frugalos/frugalos"


### PR DESCRIPTION
The main purpose of this version is to include the changes in https://github.com/frugalos/cannyls/pull/16.