### PR TITLE
Set logger to RpcServerBuilder.

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -104,6 +104,7 @@ impl FrugalosDaemon {
             ThreadPoolExecutor::with_thread_count(builder.executor_threads).map_err(Error::from)
         )?;
         let rpc_service = RpcServiceBuilder::new()
+            .logger(logger.clone())
             .channel_options(builder.rpc_client_channel_options.clone())
             .finish(executor.handle());
 


### PR DESCRIPTION
Revert the change because I accidentally removed `.logger(logger.clone())` in c07262cf2024c1d1b9a3311e2c6034bde24bbec7.

:bowing_man: 