### PR TITLE
Replies an error to a request if a node is stopping or stopped.

### DIFF
--- a/frugalos_mds/src/error.rs
+++ b/frugalos_mds/src/error.rs
@@ -25,6 +25,9 @@ pub enum ErrorKind {
     /// リーダ以外に対して要求が発行された.
     NotLeader,
 
+    /// リクエストを受け付けられる状態ではない.
+    Unavailable,
+
     /// その他のエラー.
     Other,
 }
@@ -40,9 +43,8 @@ impl From<libfrugalos::Error> for Error {
             libfrugalos::ErrorKind::InvalidInput => ErrorKind::InvalidInput,
             libfrugalos::ErrorKind::NotLeader => ErrorKind::NotLeader,
             libfrugalos::ErrorKind::Unexpected(v) => ErrorKind::Unexpected(v),
-            libfrugalos::ErrorKind::Unavailable
-            | libfrugalos::ErrorKind::Timeout
-            | libfrugalos::ErrorKind::Other => ErrorKind::Other,
+            libfrugalos::ErrorKind::Unavailable => ErrorKind::Unavailable,
+            libfrugalos::ErrorKind::Timeout | libfrugalos::ErrorKind::Other => ErrorKind::Other,
         };
         kind.takes_over(f).into()
     }
@@ -124,6 +126,7 @@ impl From<fibers_tasque::AsyncCallError> for Error {
 pub fn to_rpc_error(e: Error) -> libfrugalos::Error {
     let kind = match *e.kind() {
         ErrorKind::InvalidInput => libfrugalos::ErrorKind::InvalidInput,
+        ErrorKind::Unavailable => libfrugalos::ErrorKind::Unavailable,
         ErrorKind::NotLeader => libfrugalos::ErrorKind::NotLeader,
         ErrorKind::Unexpected(v) => libfrugalos::ErrorKind::Unexpected(v),
         ErrorKind::Other => libfrugalos::ErrorKind::Other,


### PR DESCRIPTION
## Problem

frugalos_mds and cannyls storage becomes inconsistent if a PUT request fails in the middle of `PUT` steps. Such a failure may occur when frugalos_mds is stopping because it looks that in-flight requests is discarded before finishing successfully.

After such an error happens, frugalos responds to `HEAD` request with 200 and to `GET` request with 500. This is because frugalos drops a request before storing given data into physical devices.

##  Changes

This PR reduces the possibility of the above error by sending an error to a client after stopping process begins. I guess that the average drop rate gets increased in comparison to the current implementation of `frugalos_mds/src/node/node.rs`.