### PR TITLE
add an error information to error returned by CollectFragments

### DIFF
--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -625,10 +625,18 @@ impl CollectFragments {
         while force || self.futures.len() + self.fragments.len() < self.data_fragments {
             force = false;
 
-            let m = track!(self
-                .spares
-                .pop()
-                .ok_or_else(|| ErrorKind::Corrupted.error(),))?;
+            let m = if let Some(m) = self.spares.pop() {
+                m
+            } else {
+                let there_are_not_enough_fragments_error =
+                        ErrorKind::Corrupted
+                        .cause(format!("There are no enough fragments (Detail: futures.len({}) + fragments.len({}) < data_fragments({}))",
+                                       self.futures.len(),
+                                       self.fragments.len(),
+                                       self.data_fragments));
+                track!(Err(there_are_not_enough_fragments_error))?
+            };
+
             let client = CannyLsClient::new(m.node.addr, self.rpc_service.clone());
             let lump_id = m.make_lump_id(self.version);
             debug!(


### PR DESCRIPTION
現在のFrugalosでは、
https://github.com/frugalos/frugalos/blob/420ab1f1f223787fb054e959e9ab93d82176fb06/frugalos_segment/src/client/storage.rs#L628-L631
の部分において、 sparesベクタが空になっており、かつ次が成立しているとエラーを返す:
`self.futures.len (= これから回収できる可能性のあるfragmentの総数) + self.fragments.len() (= 既に回収できたfragmentの個数 < self.data_fragments (= 要求されているfragmentの総数)`

現在はここでエラーがあったということしか分からないので、どのような理由でエラーとしたかを付与するようにした。