### PR TITLE
Changes the rust version for releasing a new binary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   include:
   - stage: deploy-to-github
+    rust: 1.31.1
     if: tag =~ ^[0-9]\.[0-9].*$
     env:
     - FRUGALOS_IMAGE_NAME=frugalos-$TRAVIS_BUILD_ID-$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
frugalos 0.10.2 has a problem of using more memory than before(0.9.0). I guess that the issue is caused by the version of `jemalloc` changed in https://github.com/frugalos/frugalos/pull/70. Previously jemalloc 4.5.0 is used and 5.1.0 currently.

I'd like to verify by this PR whether downgrading the version of rustc to compile a binary built with not jemallocator but built-in jemalloc resolves it or not.

After merging this PR, I will attach a new binary to 0.10.2.