### PR TITLE
Fix typo (replcated -> replicated)

### DIFF
--- a/apidoc/v1/buckets.md
+++ b/apidoc/v1/buckets.md
@@ -40,7 +40,7 @@ HOST: http://example.com
 
 + One Of
   + dispersed (DispersedBucket)
-  + replcated (ReplicatedBucket)
+  + replicated (ReplicatedBucket)
   + metadata (MetadataBucket)
 
 ### BucketListItem

--- a/docs/v1/buckets.html
+++ b/docs/v1/buckets.html
@@ -304,7 +304,7 @@
     </span>},
     {
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">replcated</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">replicated</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
           "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
             "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
@@ -463,7 +463,7 @@
     </span>},
     {
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">replcated</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">replicated</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
           "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
             "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
@@ -592,7 +592,7 @@
     </span>},
     {
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">replcated</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">replicated</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
           "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
             "<span class="hljs-attribute">id</span>": <span class="hljs-value">{
@@ -721,7 +721,7 @@
     </span>},
     {
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
-        "<span class="hljs-attribute">replcated</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">replicated</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
           "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
             "<span class="hljs-attribute">id</span>": <span class="hljs-value">{


### PR DESCRIPTION
Typos in `docs/` and `apidoc/` are fixed.