### PR TITLE
Add two log level options, error and critical

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
                 .short("l")
                 .long("loglevel")
                 .takes_value(true)
-                .possible_values(&["debug", "info", "warning"])
+                .possible_values(&["debug", "info", "warning", "error", "critical"])
                 .default_value("info"),
         )
         .arg(
@@ -120,6 +120,8 @@ fn main() {
         "debug" => sloggers::types::Severity::Debug,
         "info" => sloggers::types::Severity::Info,
         "warning" => sloggers::types::Severity::Warning,
+        "error" => sloggers::types::Severity::Error,
+        "critical" => sloggers::types::Severity::Critical,
         _ => unreachable!(),
     };
     let max_concurrent_logs = track_try_unwrap!(matches


### PR DESCRIPTION
Frugalos uses [`slog-rs` crate](https://github.com/slog-rs/slog) as its logger; therefore, there are five log levels, `debug`, `info`, `warning`, `error` and `critical`.
However, Frugalos only allows `debug`, `info`, and `warning` as log filter options.

This PR adds the left two options `error` and `critical`.