### PR TITLE
Read configurations from a file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,11 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dtoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ecpool"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,7 +289,7 @@ dependencies = [
  "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.2.1",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,9 +297,11 @@ dependencies = [
  "rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sloggers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "trackable 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -311,7 +318,7 @@ dependencies = [
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.2.1",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -334,7 +341,7 @@ dependencies = [
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.2.1",
  "patricia_tree 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -384,7 +391,7 @@ dependencies = [
  "frugalos_mds 0.6.1",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.2.1",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,6 +407,11 @@ dependencies = [
 [[package]]
 name = "fs_extra"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -554,8 +566,7 @@ dependencies = [
 
 [[package]]
 name = "libfrugalos"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.1"
 dependencies = [
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,6 +577,11 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "trackable 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
@@ -754,6 +770,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -776,6 +804,14 @@ dependencies = [
 name = "rand_core"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -808,6 +844,14 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -894,6 +938,17 @@ dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1014,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1196,6 +1260,14 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
@@ -1218,6 +1290,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
+"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum ecpool 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b26a3d6098ac6bf3952357c8dbe386705408069942b35f6c9da5dac5233849"
 "checksum factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12035ccde1cff7c507200fd9e7ad0dbceda81d3cf6f68a265974a213d24acfde"
 "checksum fibers 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "743ec3662c26777382f2ed1184fb917055dbf89dd1f5a8b13727618f0e516228"
@@ -1226,6 +1299,7 @@ dependencies = [
 "checksum fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "30b73b231614aabb528b07ca74bd4cf5b61c4da1aea4c201fd4dea545422ea14"
 "checksum fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ec69910a085e2be9327da6c3c82556b180e8be6d91bc4e0d18b49b4b0fbf32f9"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
@@ -1245,7 +1319,7 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum liberasurecode 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9a33156ba336ec0b10cd982e7d0d7f07069e17ff3d00690475538d01054b64"
 "checksum libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
-"checksum libfrugalos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a590518701991b0930da0ff5abfebf1a01a0fde0c027aafbd55f52569916707"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -1267,13 +1341,16 @@ dependencies = [
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd4e0eb8d0eca6a416d525e9e2f888fa89fd085390222de065323a3df08dbbf5"
 "checksum raftlog_protobuf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c38029ea5a1b1d85db39ecc8cc8b7947a115c8d9be35fca064b9b6d97b55b00d"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rendezvous_hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97afc999d9cbae792094b85fb8ccdf1e154f885b057cd88fd23ac084205d900b"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -1285,6 +1362,7 @@ dependencies = [
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
@@ -1299,6 +1377,7 @@ dependencies = [
 "checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tasque 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e455dd8a096f753fe888897a99cee80b88a44096300a6b6ab5c4f5c224a0d0d"
+"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
@@ -1324,3 +1403,4 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
  "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.1",
+ "libfrugalos 0.2.2",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,7 +318,7 @@ dependencies = [
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.1",
+ "libfrugalos 0.2.2",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,7 +341,7 @@ dependencies = [
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.1",
+ "libfrugalos 0.2.2",
  "patricia_tree 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -391,7 +391,7 @@ dependencies = [
  "frugalos_mds 0.6.1",
  "frugalos_raft 0.6.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.2.1",
+ "libfrugalos 0.2.2",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "libfrugalos"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,16 @@ slog = "2"
 sloggers = "0.3"
 serde = "1"
 serde_derive = "1"
+serde_yaml = "0.8"
 trackable = "0.2"
 url = "1"
 
+[dev-dependencies]
+# TODO tempfile を使いたいが現状はコンパイルできないので諸々直す
+tempdir = "0.3"
+
 [workspace]
 members = ["frugalos_config", "frugalos_mds", "frugalos_raft", "frugalos_segment"]
+
+[patch.crates-io]
+libfrugalos = { path = "../libfrugalos" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,3 @@ tempdir = "0.3"
 
 [workspace]
 members = ["frugalos_config", "frugalos_mds", "frugalos_raft", "frugalos_segment"]
-
-[patch.crates-io]
-libfrugalos = { path = "../libfrugalos" }

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -39,7 +39,7 @@ pub(crate) fn make_lump_id(node: &NodeId, version: ObjectVersion) -> LumpId {
 }
 
 /// Configuration for `MdsClient`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MdsClientConfig {
     /// Timeout in seconds, which is used to determine an actual `Deadline` on putting a content.
     pub put_content_timeout: Seconds,

--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -56,3 +56,18 @@ pub struct ObjectValue {
     /// 中身。
     pub content: Vec<u8>,
 }
+
+/// frugalos_segment の設定を表す struct。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosSegmentConfig {
+    /// A configuration for `MdsClient`.
+    pub mds_client: config::MdsClientConfig,
+}
+
+impl Default for FrugalosSegmentConfig {
+    fn default() -> Self {
+        Self {
+            mds_client: Default::default(),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use libfrugalos;
 use libfrugalos::entity::object::ObjectVersion;
 use prometrics;
 use raftlog;
+use serde_yaml;
 use std;
 use std::io;
 use trackable::error::TrackableError;
@@ -48,6 +49,11 @@ impl From<cannyls::Error> for Error {
 }
 impl From<fibers_tasque::AsyncCallError> for Error {
     fn from(f: fibers_tasque::AsyncCallError) -> Self {
+        ErrorKind::Other.cause(f).into()
+    }
+}
+impl From<serde_yaml::Error> for Error {
+    fn from(f: serde_yaml::Error) -> Self {
         ErrorKind::Other.cause(f).into()
     }
 }
@@ -92,6 +98,16 @@ impl From<libfrugalos::Error> for Error {
             _ => ErrorKind::Other,
         };
         kind.cause(f).into()
+    }
+}
+impl From<std::net::AddrParseError> for Error {
+    fn from(f: std::net::AddrParseError) -> Self {
+        ErrorKind::InvalidInput.cause(f).into()
+    }
+}
+impl From<std::num::ParseFloatError> for Error {
+    fn from(f: std::num::ParseFloatError) -> Self {
+        ErrorKind::InvalidInput.cause(f).into()
     }
 }
 impl From<std::num::ParseIntError> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ mod tests {
         expected.loglevel = sloggers::types::Severity::Critical;
         expected.daemon.sampling_rate = 0.1;
         expected.daemon.executor_threads = 3;
+        expected.daemon.stop_waiting_time = Duration::from_secs(3000);
         expected.http_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 2222));
         expected.rpc_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 3333));
         expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,20 @@ extern crate rustracing_jaeger;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_yaml;
 extern crate siphasher;
 extern crate url;
 #[macro_use]
 extern crate slog;
+#[cfg(test)]
+extern crate tempdir;
 #[macro_use]
 extern crate trackable;
+
+use std::fs::File;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 macro_rules! dump {
     ($($e:expr),*) => {
@@ -54,3 +62,160 @@ mod service;
 
 /// クレート固有の`Result`型。
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// ファイルに書き出した時のフォーマットを調整する。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct FrugalosConfigWrapper {
+    #[serde(rename = "frugalos")]
+    config: FrugalosConfig,
+}
+
+/// frugalos の設定を表す struct。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosConfig {
+    /// データ用ディレクトリのパス。
+    pub data_dir: String,
+    /// ログをファイルに出力する場合の出力先ファイルパス。
+    pub log_file: Option<PathBuf>,
+    /// 出力するログレベルの下限。
+    pub loglevel: sloggers::types::Severity,
+    /// 同時に処理できるログの最大値。
+    pub max_concurrent_logs: usize,
+    /// デーモン向けの設定。
+    pub daemon: FrugalosDaemonConfig,
+    /// HTTP server 向けの設定。
+    pub http_server: FrugalosHttpServerConfig,
+    /// RPC server 向けの設定。
+    pub rpc_server: FrugalosRpcServerConfig,
+    /// frugalos_segment 向けの設定。
+    pub segment: frugalos_segment::FrugalosSegmentConfig,
+}
+
+impl FrugalosConfig {
+    /// Reads `FrugalosConfig` from a YAML file.
+    pub fn from_yaml<P: AsRef<Path>>(path: P) -> Result<FrugalosConfig> {
+        let file = File::open(path.as_ref()).map_err(|e| track!(Error::from(e)))?;
+        serde_yaml::from_reader::<File, FrugalosConfigWrapper>(file)
+            .map(|wrapped| wrapped.config)
+            .map_err(|e| track!(Error::from(e)))
+    }
+}
+
+impl Default for FrugalosConfig {
+    fn default() -> Self {
+        Self {
+            data_dir: Default::default(),
+            log_file: None,
+            loglevel: sloggers::types::Severity::Info,
+            max_concurrent_logs: 4096,
+            daemon: Default::default(),
+            http_server: Default::default(),
+            rpc_server: Default::default(),
+            segment: Default::default(),
+        }
+    }
+}
+
+/// `FrugalosDaemon` 向けの設定。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosDaemonConfig {
+    /// 実行スレッド数。
+    pub executor_threads: usize,
+    /// Jaegerのトレースのサンプリング確率。
+    pub sampling_rate: f64,
+}
+
+impl Default for FrugalosDaemonConfig {
+    fn default() -> FrugalosDaemonConfig {
+        Self {
+            executor_threads: num_cpus::get(),
+            sampling_rate: 0.001,
+        }
+    }
+}
+
+/// HTTP server 向けの設定。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosHttpServerConfig {
+    /// bind するアドレス。
+    pub bind_addr: SocketAddr,
+}
+
+impl Default for FrugalosHttpServerConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: SocketAddr::from(([0, 0, 0, 0], 3000)),
+        }
+    }
+}
+
+/// RPC server 向けの設定。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosRpcServerConfig {
+    /// bind するアドレス。
+    pub bind_addr: SocketAddr,
+    /// RPC の接続タイムアウト時間。
+    pub tcp_connect_timeout: Duration,
+    /// RPC の書き込みタイムアウト時間。
+    pub tcp_write_timeout: Duration,
+}
+
+impl FrugalosRpcServerConfig {
+    fn channel_options(&self) -> fibers_rpc::channel::ChannelOptions {
+        let mut options = fibers_rpc::channel::ChannelOptions::default();
+        options.tcp_connect_timeout = self.tcp_connect_timeout;
+        options.tcp_write_timeout = self.tcp_write_timeout;
+        options
+    }
+}
+
+impl Default for FrugalosRpcServerConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: SocketAddr::from(([127, 0, 0, 1], 14278)),
+            tcp_connect_timeout: Duration::from_millis(5000),
+            tcp_write_timeout: Duration::from_millis(5000),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libfrugalos::time::Seconds;
+    use std::fs::File;
+    use std::io::Write;
+    use tempdir::TempDir;
+    use trackable::result::TestResult;
+
+    #[test]
+    fn config_file_parsing_works() -> TestResult {
+        let mut expected = FrugalosConfig::default();
+
+        expected.max_concurrent_logs = 30;
+        expected.loglevel = sloggers::types::Severity::Critical;
+        expected.daemon.sampling_rate = 0.1;
+        expected.daemon.executor_threads = 3;
+        expected.http_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 2222));
+        expected.rpc_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 3333));
+        expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);
+        expected.rpc_server.tcp_write_timeout = Duration::from_secs(10);
+        expected.segment.mds_client.put_content_timeout = Seconds(32);
+
+        let wrapper = FrugalosConfigWrapper {
+            config: expected.clone(),
+        };
+        let content = track_any_err!(serde_yaml::to_string(&wrapper))?;
+        let dir = track_any_err!(TempDir::new("frugalos_test"))?;
+        let filepath = dir.path().join("frugalos.yml");
+        let mut file = track_any_err!(File::create(filepath.clone()))?;
+
+        track_any_err!(file.write(content.as_bytes()))?;
+
+        let config: FrugalosConfig = track!(FrugalosConfig::from_yaml(filepath))?;
+
+        assert_eq!(expected, config);
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,22 +29,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[allow(clippy::cyclomatic_complexity)]
 fn main() {
-    let max_concurrent_logs = FrugalosConfig::default().max_concurrent_logs.to_string();
-    let http_server_bind_addr = FrugalosConfig::default().http_server.bind_addr.to_string();
     let rpc_server_bind_addr = FrugalosConfig::default().rpc_server.bind_addr.to_string();
-    let jaeger_sampling_rate = FrugalosConfig::default().daemon.sampling_rate.to_string();
-    let tcp_connect_timeout_millis = (FrugalosConfig::default()
-        .rpc_server
-        .tcp_connect_timeout
-        .as_secs()
-        * 1000)
-        .to_string();
-    let tcp_write_timeout_millis = (FrugalosConfig::default()
-        .rpc_server
-        .tcp_write_timeout
-        .as_secs()
-        * 1000)
-        .to_string();
     let matches = App::new("frugalos")
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand(
@@ -70,8 +55,7 @@ fn main() {
                 .arg(
                     Arg::with_name("SAMPLING_RATE")
                         .long("sampling-rate")
-                        .takes_value(true)
-                        .default_value(&jaeger_sampling_rate),
+                        .takes_value(true),
                 )
                 .arg(
                     Arg::with_name("EXECUTOR_THREADS")
@@ -81,20 +65,17 @@ fn main() {
                 .arg(
                     Arg::with_name("HTTP_SERVER_BIND_ADDR")
                         .long("http-server-bind-addr")
-                        .takes_value(true)
-                        .default_value(&http_server_bind_addr),
+                        .takes_value(true),
                 )
                 .arg(
                     Arg::with_name("RPC_CONNECT_TIMEOUT_MILLIS")
                         .long("rpc-connect-timeout-millis")
-                        .takes_value(true)
-                        .default_value(&tcp_connect_timeout_millis),
+                        .takes_value(true),
                 )
                 .arg(
                     Arg::with_name("RPC_WRITE_TIMEOUT_MILLIS")
                         .long("rpc-write-timeout-millis")
-                        .takes_value(true)
-                        .default_value(&tcp_write_timeout_millis),
+                        .takes_value(true),
                 )
                 .arg(data_dir_arg())
                 .arg(put_content_timeout_arg()),
@@ -120,14 +101,12 @@ fn main() {
                 .short("l")
                 .long("loglevel")
                 .takes_value(true)
-                .possible_values(&["debug", "info", "warning", "error", "critical"])
-                .default_value("info"),
+                .possible_values(&["debug", "info", "warning", "error", "critical"]),
         )
         .arg(
             Arg::with_name("MAX_CONCURRENT_LOGS")
                 .long("max_concurrent_logs")
-                .takes_value(true)
-                .default_value(&max_concurrent_logs),
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("CONFIG_FILE")
@@ -311,7 +290,6 @@ fn server_addr_arg<'a, 'b>() -> Arg<'a, 'b> {
         .long("addr")
         .alias("rpc-addr")
         .takes_value(true)
-        .default_value("127.0.0.1:14278")
 }
 
 fn contact_server_addr_arg<'a, 'b>() -> Arg<'a, 'b> {
@@ -336,7 +314,6 @@ fn put_content_timeout_arg<'a, 'b>() -> Arg<'a, 'b> {
         .help("Sets timeout in seconds on putting a content.")
         .long("put-content-timeout")
         .takes_value(true)
-        .default_value("60")
 }
 
 fn set_data_dir(matches: &ArgMatches, config: &mut FrugalosConfig) {
@@ -350,7 +327,7 @@ fn set_data_dir(matches: &ArgMatches, config: &mut FrugalosConfig) {
 
     if config.data_dir.is_empty() {
         println!(
-            "[ERROR] Must set the `data-dir` argument, the `FRUGALOS_DATA_DIR` environment variable or the `frugalos.data_dir` key of a configuration file"
+            "[ERROR] Must set one of the `data-dir` argument, the `FRUGALOS_DATA_DIR` environment variable or the `frugalos.data_dir` key of a configuration file"
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
This PR resolves https://github.com/frugalos/frugalos/issues/79.

You can get the specification of a configuration file at https://github.com/frugalos/frugalos/wiki/Configuration.

## Usage

Changes in this PR are compatible with the earlier versions, that is, you still do like:

```console
$ frugalos create --id srv1 --data-dir /path/to/srv1 --addr 127.0.0.1:3100
$ frugalos start --data-dir /path/to/srv1/ --http-server-bind-addr 0.0.0.0:3000
```

The new form introduced by this PR:

```console
$ frugalos --config-file /path/to/frugalos.yml create
$ frugalos --config-file /path/to/frugalos.yml start
```

Remember that `--config-file` option must be provided before a subcommand because configuration values included in a configuration file affects global options such as a logging option.