### PR TITLE
Futureをcancelするための補助的なmoduleを追加し、frugalos_config::cluster::createで用いている

### DIFF
--- a/frugalos_config/src/cancelable_future.rs
+++ b/frugalos_config/src/cancelable_future.rs
@@ -1,0 +1,94 @@
+use futures::{Async, Future, Poll};
+use std::sync::mpsc;
+use Error;
+
+/// Signalを受信するための構造体であり、Futureとしても扱うことができる。  
+/// `make_signal`関数によって、対応するSenderとの組として生成される。
+pub struct SignalReceiver(mpsc::Receiver<()>);
+
+/// Signalを送信するための構造体である。  
+/// `make_signal`関数によって、対応するReceiverとの組として生成される。
+#[derive(Clone)]
+pub struct SignalSender(mpsc::Sender<()>);
+
+impl SignalSender {
+    /// 対応するReceiverにsignalを送信する。
+    pub fn send_signal(&mut self) -> Result<(), Error> {
+        self.0.send(()).map_err(Error::from)
+    }
+}
+
+impl Future for SignalReceiver {
+    type Item = ();
+    type Error = mpsc::TryRecvError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let result = self.0.try_recv();
+
+        match result {
+            Err(mpsc::TryRecvError::Disconnected) => Err(mpsc::TryRecvError::Disconnected),
+            Err(mpsc::TryRecvError::Empty) => Ok(Async::NotReady),
+            Ok(()) => Ok(Async::Ready(())),
+        }
+    }
+}
+
+/// Signalの送信口`SignalSender`と受信口`SignalReceiver`を生成する。
+pub fn make_signal() -> (SignalSender, SignalReceiver) {
+    let (sender, receiver) = mpsc::channel();
+    (SignalSender(sender), SignalReceiver(receiver))
+}
+
+/// `future: Future<Item = (), Error = ()>`からキャンセル可能なFutureを作るための構造体である。
+/// # Example
+///
+/// ```ignore
+/// let mut executor = track!(ThreadPoolExecutor::new().map_err(Error::from))?;
+/// let mut rpc_server_builder = RpcServerBuilder::new(node.addr);
+/// ...
+/// let rpc_server = rpc_server_builder.finish(executor.handle());
+/// let (cancelable_rpc_server, cancelizer) =
+///     Cancelable::new(rpc_server.map_err(move |e| panic!("Error: {}", e)));
+/// ...
+/// executor.spawn(cancelable_rpc_server);
+/// ...
+/// // `some_future`は終了直前に、`rpc_server`を終させるために、`cancelizer.send_signal()`を呼ぶ。
+/// executor.run_future(some_future).unwrap();
+/// ```
+pub struct Cancelable {
+    signal_rx: SignalReceiver,
+    inner: Box<Future<Item = (), Error = ()> + Send + 'static>,
+}
+
+impl Cancelable {
+    /// 受け取ったfutureをキャンセル可能なfutureに変換する。  
+    /// `let (cancelable_future, cancelizer) = Cancelable::new(future)`  
+    /// において、`cancelable_future`がキャンセル可能なfutureであり、  
+    /// このfutureをキャンセルしたくなった時点で `cancelizer.send_signal()` を呼び出せば、  
+    /// シグナル送信以降は `cancelable_future.poll() == Ok(Async::Ready())` を即時返却するようになる。
+    pub fn new<F>(future: F) -> (Self, SignalSender)
+    where
+        F: Future<Item = (), Error = ()> + Send + 'static,
+    {
+        let (signal_tx, signal_rx) = make_signal();
+        (
+            Cancelable {
+                inner: Box::new(future),
+                signal_rx,
+            },
+            signal_tx,
+        )
+    }
+}
+
+impl Future for Cancelable {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let Async::Ready(_) = self.signal_rx.poll().unwrap() {
+            return Ok(Async::Ready(()));
+        } else {
+            self.inner.poll()
+        }
+    }
+}

--- a/frugalos_config/src/error.rs
+++ b/frugalos_config/src/error.rs
@@ -60,6 +60,15 @@ impl From<libfrugalos::Error> for Error {
     }
 }
 
+impl<T> From<std::sync::mpsc::SendError<T>> for Error
+where
+    T: Send + Sync + 'static,
+{
+    fn from(f: std::sync::mpsc::SendError<T>) -> Self {
+        ErrorKind::Other.cause(f).into()
+    }
+}
+
 pub fn to_rpc_error(e: Error) -> libfrugalos::Error {
     let kind = match *e.kind() {
         ErrorKind::InvalidInput => libfrugalos::ErrorKind::InvalidInput,

--- a/frugalos_config/src/lib.rs
+++ b/frugalos_config/src/lib.rs
@@ -36,6 +36,7 @@ pub use service::{Event, Service, ServiceHandle};
 pub mod cluster;
 
 mod builder;
+mod cancelable_future;
 mod config;
 mod error;
 mod machine;


### PR DESCRIPTION
# 背景
createまたはjoin時にエラーが発生するissue https://github.com/frugalos/frugalos/issues/65 を解決するためのPR 

# 技術的背景
**fibersの内部実装に触れるので、興味がない場合は飛ばしてください**

`frugalos_config::cluster::create`関数
https://github.com/frugalos/frugalos/blob/21713490ede7405705d7685fc21a8fe5713c9a68/frugalos_config/src/cluster.rs#L120-L172
に問題があり、この関数を抜けるタイミングで`thread '<unnamed>' panicked at 'Error: Other (cause; Monitor target aborted)`が発生する。

より具体的に述べるために、以下の部分に注目する:
```rust
    let mut executor = track!(ThreadPoolExecutor::new().map_err(Error::from))?;
    ...
    let mut rpc_server_builder = RpcServerBuilder::new(node.addr);
    ...
    let rpc_server = rpc_server_builder.finish(executor.handle());
    ...
    executor.spawn(rpc_server.map_err(move |e| panic!("Error: {}", e)));
```
この関数を抜けるタイミングで、以下の流れが生じる（ことがある）:
1. `executor`のdrop処理を進行中に、`executor`の抱える（fibersレベルでの）pollersメンバ
https://github.com/dwango/fibers-rs/blob/f104bfab6bc73cbdf159529f810eacd39fda8f52/src/executor/thread_pool.rs#L48-L55
がdropされる
2. rpc_serverの抱えるmonitorを使おうとする（spawn済みなのでrpc_server以下は別スレッドで実行されていることに注意する）
https://github.com/dwango/fibers-rs/blob/f104bfab6bc73cbdf159529f810eacd39fda8f52/src/net/tcp.rs#L150-L153
3. このmonitorに対して情報を送るmonitoredは、1でdrop済みのpollersメンバが抱えているため既に削除されているため、`Monitor target aborted`エラーが生じる。

# 解決策
https://github.com/frugalos/frugalos/blob/21713490ede7405705d7685fc21a8fe5713c9a68/frugalos_config/src/cluster.rs#L157-L160
この部分の処理以降では`rpc_server`の機能は一切用いないため、ここで呼び出している`run_fiber`が終了するタイミングで`rpc_server`をストップさせたい。

そのために、`frugalos_config`に、与えられたfutureをストップ可能なfutureに変形するためのmoduleを加えた:
https://github.com/frugalos/frugalos/blob/633c30a90fe71b7edd204292d17169a9b68e491d/frugalos_config/src/cancelable_future.rs#L1-L94

このmoduleを用いて、当該部分の処理終了時に明示的に`rpc_server`も終了できるようになった。
https://github.com/frugalos/frugalos/commit/633c30a90fe71b7edd204292d17169a9b68e491d#diff-beb8c697d4024dccdaa05ffed9a45ad1

停止のための具体的な処理は次の部分である:
https://github.com/frugalos/frugalos/blob/633c30a90fe71b7edd204292d17169a9b68e491d/frugalos_config/src/cluster.rs#L301-L304
ここで処理終了直前に、キャンセル可能となった`rpc_server` futureに対して停止シグナルを送信している。