### PR TITLE
Determines a snapshot threshold from a range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,8 @@ dependencies = [
  "raftlog 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/frugalos_mds/Cargo.toml
+++ b/frugalos_mds/Cargo.toml
@@ -28,6 +28,8 @@ protobuf_codec = "0.2"
 raftlog = "0.4"
 rand = "0.5"
 rustracing = "0.1"
+serde = "1"
+serde_derive = "1"
 slog = "2"
 trackable = "0.2"
 

--- a/frugalos_mds/src/lib.rs
+++ b/frugalos_mds/src/lib.rs
@@ -28,8 +28,13 @@ extern crate rand;
 extern crate rustracing;
 #[macro_use]
 extern crate slog;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 #[macro_use]
 extern crate trackable;
+
+use std::ops::Range;
 
 pub use error::{Error, ErrorKind};
 pub use node::{Event, Node};
@@ -45,3 +50,30 @@ mod service;
 
 /// クレート固有の`Result`型.
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// `frugalos_mds` の設定.
+/// 以下の理由で現時点では module 毎に設定を struct で分けていない。
+/// - ほとんどの設定が `Node` のためのものであること。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosMdsConfig {
+    /// スナップショットを取る際の閾値(レンジの両端を含む).
+    ///
+    /// `Node` のローカルログの長さが、この値を超えた場合に、スナップショットの取得が開始される.
+    #[serde(default = "default_threshold")]
+    pub snapshot_threshold: Range<usize>,
+}
+
+impl Default for FrugalosMdsConfig {
+    fn default() -> Self {
+        Self {
+            snapshot_threshold: default_threshold(),
+        }
+    }
+}
+
+fn default_threshold() -> Range<usize> {
+    Range {
+        start: 9_500,
+        end: 10_500,
+    }
+}

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -16,6 +16,7 @@ pub use self::node::Node;
 
 mod handle;
 mod node;
+mod snapshot;
 
 type Reply<T> = Monitored<T, Error>;
 

--- a/frugalos_mds/src/node/snapshot.rs
+++ b/frugalos_mds/src/node/snapshot.rs
@@ -1,0 +1,140 @@
+use rand::{Rng, SeedableRng, StdRng};
+use std::fmt;
+use std::iter;
+use std::ops::Range;
+use trackable::error::ErrorKindExt;
+
+use {ErrorKind, Result};
+
+/// The length of a seed.
+const SEED_LENGTH: usize = 32;
+
+/// This struct represents a threshold of taking a snapshot.
+#[derive(Debug)]
+pub struct SnapshotThreshold {
+    /// The random number generator, which is initialized by a seed.
+    rng: StdRng,
+    /// The value range which this threshold may take.
+    range: Range<usize>,
+    /// The current value of this threshold.
+    current: usize,
+}
+
+impl SnapshotThreshold {
+    /// Creates a new `SnapshotThreshold` from the specified seed and range.
+    pub fn new(seed: &str, range: Range<usize>) -> Result<Self> {
+        if range.start > range.end {
+            return Err(ErrorKind::InvalidInput
+                .cause(format!(
+                    "The start of range({:?}) must be smaller or equal than the end",
+                    range
+                ))
+                .into());
+        }
+        let mut rng_seed = [0u8; 32];
+        fill_rng_seed(&mut rng_seed, seed);
+        let mut this = Self {
+            rng: SeedableRng::from_seed(rng_seed),
+            range,
+            current: Default::default(),
+        };
+        this.refresh();
+        Ok(this)
+    }
+}
+
+impl SnapshotThreshold {
+    /// Returns the current threshold value.
+    pub fn value(&self) -> usize {
+        self.current
+    }
+
+    /// Updates the current threshold value randomly within the range.
+    pub fn refresh(&mut self) {
+        let range: Vec<usize> = (self.range.start..=self.range.end).collect();
+        self.current = *self.rng.choose(&range).expect("Never fails");
+    }
+}
+
+impl fmt::Display for SnapshotThreshold {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "SnapshotThreshold(range = {:?}, current = {})",
+            self.range, self.current
+        )
+    }
+}
+
+/// Fills up the specified seed with `src`. `seed` must be `[u8; 32]`.
+fn fill_rng_seed(seed: &mut [u8], src: &str) {
+    let len = src.len();
+    let mut src = src.to_owned();
+    if len < SEED_LENGTH {
+        // Zero padding is acceptable because we don't need a random seed here.
+        src.extend(iter::repeat("0").take(SEED_LENGTH - len));
+    }
+    seed.copy_from_slice(src.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trackable::result::TestResult;
+
+    const SEED: &str = "xCZw9dir5QixSgZVzjvve7UXUZbYf2eD";
+
+    #[test]
+    fn it_works() -> TestResult {
+        let range = Range { start: 0, end: 100 };
+        let mut threshold = track!(SnapshotThreshold::new(SEED, range))?;
+        assert_eq!(20, threshold.value());
+        threshold.refresh();
+        assert_eq!(31, threshold.value());
+        Ok(())
+    }
+
+    #[test]
+    fn it_works_with_minimum_range() -> TestResult {
+        let range = Range { start: 1, end: 1 };
+        let mut threshold = track!(SnapshotThreshold::new(SEED, range))?;
+        assert_eq!(1, threshold.value());
+        threshold.refresh();
+        assert_eq!(1, threshold.value());
+        threshold.refresh();
+        assert_eq!(1, threshold.value());
+        Ok(())
+    }
+
+    #[test]
+    fn it_rejects_invalid_range() -> TestResult {
+        assert!(SnapshotThreshold::new(SEED, Range { start: 3, end: 2 }).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn fill_rng_seed_works() {
+        let mut seed = [0u8; 32];
+        let src = "cUz598523AtArTqzxAcYBXTdTaCqi4Wk";
+        fill_rng_seed(&mut seed, src);
+        assert_eq!(src.as_bytes(), seed);
+    }
+
+    #[test]
+    fn fill_rng_seed_fills_insufficient_range() {
+        let mut seed = [0u8; 32];
+        let src = "cUz";
+        let len = SEED_LENGTH - src.len();
+        let filled = iter::repeat(48).take(len).collect::<Vec<u8>>();
+        fill_rng_seed(&mut seed, &src);
+        assert_eq!([99, 85, 122], seed[0..3]);
+        assert_eq!(filled.as_slice(), &seed[3..]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn fill_rng_seed_panics() {
+        let mut seed = [0u8; 31];
+        fill_rng_seed(&mut seed, "abc");
+    }
+}

--- a/frugalos_mds/src/node/snapshot.rs
+++ b/frugalos_mds/src/node/snapshot.rs
@@ -17,6 +17,9 @@ pub struct SnapshotThreshold {
     /// The value range which this threshold may take.
     range: Range<usize>,
     /// The current value of this threshold.
+    /// invariant: range.start <= current <= range.end
+    /// NOTE: We don't add assert! for this invariant because it's not critical
+    ///       even if this invariant is not satisfied strictly.
     current: usize,
 }
 

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -12,6 +12,7 @@ pub mod tests {
     use fibers_global;
     use fibers_rpc::client::{ClientService, ClientServiceHandle};
     use fibers_rpc::server::ServerBuilder;
+    use frugalos_mds;
     use frugalos_raft::{self, LocalNodeId, NodeId};
     use futures;
     use futures::future::Future;
@@ -95,6 +96,7 @@ pub mod tests {
                 rpc_service_handle.clone(),
                 &mut rpc_server_builder,
                 raft_service_handle,
+                frugalos_mds::FrugalosMdsConfig::default(),
             )?;
             let service_handle = service.handle();
             let device_registry_handle = service.device_registry().handle();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -85,6 +85,7 @@ impl FrugalosDaemon {
             config_service,
             &mut rpc_server_builder,
             rpc_service.handle(),
+            config.mds,
             config.segment.mds_client,
         ))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub struct FrugalosConfig {
     pub http_server: FrugalosHttpServerConfig,
     /// RPC server 向けの設定。
     pub rpc_server: FrugalosRpcServerConfig,
+    /// frugalos_mds 向けの設定。
+    pub mds: frugalos_mds::FrugalosMdsConfig,
     /// frugalos_segment 向けの設定。
     pub segment: frugalos_segment::FrugalosSegmentConfig,
 }
@@ -111,6 +113,7 @@ impl Default for FrugalosConfig {
             daemon: Default::default(),
             http_server: Default::default(),
             rpc_server: Default::default(),
+            mds: Default::default(),
             segment: Default::default(),
         }
     }
@@ -188,6 +191,7 @@ mod tests {
     use libfrugalos::time::Seconds;
     use std::fs::File;
     use std::io::Write;
+    use std::ops::Range;
     use tempdir::TempDir;
     use trackable::result::TestResult;
 
@@ -216,6 +220,10 @@ frugalos:
     tcp_write_timeout:
       secs: 10
       nanos: 0
+  mds:
+    snapshot_threshold:
+      start: 100
+      end: 200
   segment:
     mds_client:
       put_content_timeout: 32"##;
@@ -237,6 +245,10 @@ frugalos:
         expected.rpc_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 3333));
         expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);
         expected.rpc_server.tcp_write_timeout = Duration::from_secs(10);
+        expected.mds.snapshot_threshold = Range {
+            start: 100,
+            end: 200,
+        };
         expected.segment.mds_client.put_content_timeout = Seconds(32);
 
         assert_eq!(expected, actual);

--- a/src/service.rs
+++ b/src/service.rs
@@ -63,6 +63,8 @@ impl<S> Service<S>
 where
     S: Spawn + Send + Clone + 'static,
 {
+    // FIXME: 引数を減らす方法を考える
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         logger: Logger,
         spawner: S,

--- a/src/service.rs
+++ b/src/service.rs
@@ -10,6 +10,7 @@ use fibers_rpc::server::ServerBuilder as RpcServerBuilder;
 use fibers_tasque;
 use fibers_tasque::TaskQueueExt;
 use frugalos_config::{DeviceGroup, Event as ConfigEvent, Service as ConfigService};
+use frugalos_mds;
 use frugalos_raft::Service as RaftService;
 use frugalos_segment;
 use frugalos_segment::config::MdsClientConfig;
@@ -69,6 +70,7 @@ where
         config_service: ConfigService,
         rpc: &mut RpcServerBuilder,
         rpc_service: RpcServiceHandle,
+        mds_config: frugalos_mds::FrugalosMdsConfig,
         mds_client_config: MdsClientConfig,
     ) -> Result<Self> {
         let frugalos_segment_service = track!(SegmentService::new(
@@ -77,6 +79,7 @@ where
             rpc_service.clone(),
             rpc,
             raft_service.handle(),
+            mds_config,
         ))?;
         Ok(Service {
             logger,


### PR DESCRIPTION
スナップショットの閾値を値の範囲からランダムに選択する。特に frugalos 起動時に顕著だが、同じ周期でスナップショットが取得されるのを防ぐ目的がある。