### PR TITLE
Add configuration values for a dispersed client

### DIFF
--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -421,7 +421,7 @@ impl DispersedClient {
             deadline,
             rpc_service: self.rpc_service,
             parent: span.handle(),
-            timeout: Some(timer::timeout(self.client_config.get_timeout.clone())),
+            timeout: Some(timer::timeout(self.client_config.get_timeout)),
         };
         Box::new(DispersedGet {
             phase: Phase::A(future),

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -7,6 +7,7 @@ use libfrugalos::time::Seconds;
 use raftlog::cluster::ClusterMembers;
 use siphasher::sip::SipHasher;
 use std::hash::{Hash, Hasher};
+use std::time::Duration;
 
 // TODO: LumpIdの名前空間の使い方に関してWikiに記載する
 pub(crate) const LUMP_NAMESPACE_CONTENT: u8 = 1;
@@ -54,12 +55,29 @@ impl Default for MdsClientConfig {
     }
 }
 
-// FIXME: rename
+/// Configuration for `DispersedClient`.
+/// This struct mainly focuses on a client configurations.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DispersedClientConfig {
+    /// How long to wait before aborting a get operation.
+    pub get_timeout: Duration,
+}
+
+impl Default for DispersedClientConfig {
+    fn default() -> Self {
+        DispersedClientConfig {
+            get_timeout: Duration::from_secs(2),
+        }
+    }
+}
+
+// FIXME: rename (config.rs で定義されている struct は名前、責務、依存関係を整理した方がよい)
 /// クライアントがセグメントにアクセスする際に使用する構成情報。
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
     pub cluster: ClusterConfig,
+    pub dispersed_client: DispersedClientConfig,
     pub storage: Storage,
     pub mds: MdsClientConfig,
 }

--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -60,13 +60,18 @@ pub struct ObjectValue {
 /// frugalos_segment の設定を表す struct。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FrugalosSegmentConfig {
+    /// A configuration for a dispersed client.
+    #[serde(default)]
+    pub dispersed_client: config::DispersedClientConfig,
     /// A configuration for `MdsClient`.
+    #[serde(default)]
     pub mds_client: config::MdsClientConfig,
 }
 
 impl Default for FrugalosSegmentConfig {
     fn default() -> Self {
         Self {
+            dispersed_client: Default::default(),
             mds_client: Default::default(),
         }
     }

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -216,6 +216,7 @@ pub mod tests {
                 self.rpc_service_handle.clone(),
                 ClientConfig {
                     cluster: self.cluster_config.clone(),
+                    dispersed_client: Default::default(),
                     storage: self.make_dispersed_storage(),
                     mds: MdsClientConfig::default(),
                 },

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -85,7 +85,7 @@ impl FrugalosDaemon {
             config_service,
             &mut rpc_server_builder,
             rpc_service.handle(),
-            config.segment.mds_client,
+            config.segment,
         ))?;
 
         let sampler = Sampler::<SpanContextState>::or(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,10 @@ frugalos:
       secs: 10
       nanos: 0
   segment:
+    dispersed_client:
+      get_timeout:
+        secs: 4
+        nanos: 0
     mds_client:
       put_content_timeout: 32"##;
         let dir = track_any_err!(TempDir::new("frugalos_test"))?;
@@ -254,6 +258,7 @@ frugalos:
         expected.rpc_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 3333));
         expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);
         expected.rpc_server.tcp_write_timeout = Duration::from_secs(10);
+        expected.segment.dispersed_client.get_timeout = Duration::from_secs(4);
         expected.segment.mds_client.put_content_timeout = Seconds(32);
 
         assert_eq!(expected, actual);

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,7 +12,7 @@ use fibers_tasque::TaskQueueExt;
 use frugalos_config::{DeviceGroup, Event as ConfigEvent, Service as ConfigService};
 use frugalos_raft::Service as RaftService;
 use frugalos_segment;
-use frugalos_segment::config::MdsClientConfig;
+use frugalos_segment::FrugalosSegmentConfig;
 use frugalos_segment::Service as SegmentService;
 use futures::future::Fuse;
 use futures::{Async, Future, Poll, Stream};
@@ -56,7 +56,7 @@ pub struct Service<S> {
 
     servers: HashMap<ServerId, Server>,
 
-    mds_client_config: MdsClientConfig,
+    segment_config: FrugalosSegmentConfig,
 }
 impl<S> Service<S>
 where
@@ -69,7 +69,7 @@ where
         config_service: ConfigService,
         rpc: &mut RpcServerBuilder,
         rpc_service: RpcServiceHandle,
-        mds_client_config: MdsClientConfig,
+        segment_config: FrugalosSegmentConfig,
     ) -> Result<Self> {
         let frugalos_segment_service = track!(SegmentService::new(
             logger.clone(),
@@ -91,7 +91,7 @@ where
             buckets: Arc::new(AtomicImmut::new(HashMap::new())),
             bucket_no_to_id: HashMap::new(),
             servers: HashMap::new(),
-            mds_client_config,
+            segment_config,
         })
     }
     pub fn client(&self) -> FrugalosClient {
@@ -159,7 +159,7 @@ where
             self.logger.clone(),
             self.rpc_service.clone(),
             &bucket_config,
-            self.mds_client_config.clone(),
+            self.segment_config.clone(),
         );
         let mut buckets = (&*self.buckets.load()).clone();
         buckets.insert(id, bucket);


### PR DESCRIPTION
This PR resolves https://github.com/frugalos/frugalos/issues/85 and enables DispersedClient to be configured with runtime configuration values.