### PR TITLE
Add configuration values for frugalos_mds node

### DIFF
--- a/frugalos_mds/src/config.rs
+++ b/frugalos_mds/src/config.rs
@@ -1,19 +1,23 @@
-//! mds の設定を定義しているcrate.
+//! mds の設定を定義しているcrate。
 
 use std::ops::Range;
 use std::time::Duration;
 
-/// `frugalos_mds` の設定.
+/// `frugalos_mds` の設定。
+///
 /// 以下の理由で現時点では module 毎に設定を struct で分けていない。
+///
 /// - ほとんどの設定が `Node` のためのものであること。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FrugalosMdsConfig {
     /// コミットをタイムアウトさせるかどうかを決める閾値。
+    ///
     /// この設定値の1単位は `node_polling_interval` である点に注意。
     #[serde(default = "default_commit_timeout_threshold")]
     pub commit_timeout_threshold: usize,
 
     /// proposal キューが長すぎる(リーダーが重い)と判断する基準となる閾値。
+    ///
     /// この設定値の1単位は `node_polling_interval` である点に注意。
     #[serde(default = "default_large_proposal_queue_threshold")]
     pub large_proposal_queue_threshold: usize,
@@ -23,6 +27,7 @@ pub struct FrugalosMdsConfig {
     pub large_leader_waiting_queue_threshold: usize,
 
     /// リーダー選出待ちをあきらめるまでの閾値。
+    ///
     /// この設定値の1単位は `node_polling_interval` である点に注意。
     #[serde(default = "default_leader_waiting_timeout_threshold")]
     pub leader_waiting_timeout_threshold: usize,
@@ -32,6 +37,7 @@ pub struct FrugalosMdsConfig {
     pub node_polling_interval: Duration,
 
     /// リーダが重い場合に再選出を行うかどうかを決める閾値。
+    ///
     /// この設定値の1単位は `node_polling_interval` である点に注意。
     #[serde(default = "default_reelection_threshold")]
     pub reelection_threshold: usize,

--- a/frugalos_mds/src/config.rs
+++ b/frugalos_mds/src/config.rs
@@ -1,0 +1,89 @@
+//! mds の設定を定義しているcrate.
+
+use std::ops::Range;
+use std::time::Duration;
+
+/// `frugalos_mds` の設定.
+/// 以下の理由で現時点では module 毎に設定を struct で分けていない。
+/// - ほとんどの設定が `Node` のためのものであること。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrugalosMdsConfig {
+    /// コミットをタイムアウトさせるかどうかを決める閾値。
+    /// この設定値の1単位は `node_polling_interval` である点に注意。
+    #[serde(default = "default_commit_timeout_threshold")]
+    pub commit_timeout_threshold: usize,
+
+    /// proposal キューが長すぎる(リーダーが重い)と判断する基準となる閾値。
+    /// この設定値の1単位は `node_polling_interval` である点に注意。
+    #[serde(default = "default_large_proposal_queue_threshold")]
+    pub large_proposal_queue_threshold: usize,
+
+    /// リーダー選出待ちキューが長すぎると判断する基準となる閾値。
+    #[serde(default = "default_large_leader_waiting_queue_threshold")]
+    pub large_leader_waiting_queue_threshold: usize,
+
+    /// リーダー選出待ちをあきらめるまでの閾値。
+    /// この設定値の1単位は `node_polling_interval` である点に注意。
+    #[serde(default = "default_leader_waiting_timeout_threshold")]
+    pub leader_waiting_timeout_threshold: usize,
+
+    /// node がポーリングする間隔。
+    #[serde(default = "default_node_polling_interval")]
+    pub node_polling_interval: Duration,
+
+    /// リーダが重い場合に再選出を行うかどうかを決める閾値。
+    /// この設定値の1単位は `node_polling_interval` である点に注意。
+    #[serde(default = "default_reelection_threshold")]
+    pub reelection_threshold: usize,
+
+    /// スナップショットを取る際の閾値(レンジの両端を含む).
+    ///
+    /// `Node` のローカルログの長さが、この値を超えた場合に、スナップショットの取得が開始される.
+    #[serde(default = "default_snapshot_threshold")]
+    pub snapshot_threshold: Range<usize>,
+}
+
+impl Default for FrugalosMdsConfig {
+    fn default() -> Self {
+        Self {
+            commit_timeout_threshold: default_commit_timeout_threshold(),
+            large_proposal_queue_threshold: default_large_proposal_queue_threshold(),
+            large_leader_waiting_queue_threshold: default_large_leader_waiting_queue_threshold(),
+            leader_waiting_timeout_threshold: default_leader_waiting_timeout_threshold(),
+            node_polling_interval: default_node_polling_interval(),
+            reelection_threshold: default_reelection_threshold(),
+            snapshot_threshold: default_snapshot_threshold(),
+        }
+    }
+}
+
+fn default_commit_timeout_threshold() -> usize {
+    30
+}
+
+fn default_large_proposal_queue_threshold() -> usize {
+    1024
+}
+
+fn default_large_leader_waiting_queue_threshold() -> usize {
+    10000
+}
+
+fn default_leader_waiting_timeout_threshold() -> usize {
+    10
+}
+
+fn default_node_polling_interval() -> Duration {
+    Duration::from_millis(500)
+}
+
+fn default_reelection_threshold() -> usize {
+    10
+}
+
+fn default_snapshot_threshold() -> Range<usize> {
+    Range {
+        start: 9_500,
+        end: 10_500,
+    }
+}

--- a/frugalos_mds/src/lib.rs
+++ b/frugalos_mds/src/lib.rs
@@ -34,13 +34,13 @@ extern crate serde_derive;
 #[macro_use]
 extern crate trackable;
 
-use std::ops::Range;
-
+pub use config::FrugalosMdsConfig;
 pub use error::{Error, ErrorKind};
 pub use node::{Event, Node};
 pub use service::{Service, ServiceHandle};
 
 mod codec;
+mod config;
 mod error;
 mod machine;
 mod node;
@@ -50,30 +50,3 @@ mod service;
 
 /// クレート固有の`Result`型.
 pub type Result<T> = ::std::result::Result<T, Error>;
-
-/// `frugalos_mds` の設定.
-/// 以下の理由で現時点では module 毎に設定を struct で分けていない。
-/// - ほとんどの設定が `Node` のためのものであること。
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct FrugalosMdsConfig {
-    /// スナップショットを取る際の閾値(レンジの両端を含む).
-    ///
-    /// `Node` のローカルログの長さが、この値を超えた場合に、スナップショットの取得が開始される.
-    #[serde(default = "default_threshold")]
-    pub snapshot_threshold: Range<usize>,
-}
-
-impl Default for FrugalosMdsConfig {
-    fn default() -> Self {
-        Self {
-            snapshot_threshold: default_threshold(),
-        }
-    }
-}
-
-fn default_threshold() -> Range<usize> {
-    Range {
-        start: 9_500,
-        end: 10_500,
-    }
-}

--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -57,7 +57,7 @@ pub struct ObjectValue {
     pub content: Vec<u8>,
 }
 
-/// frugalos_segment の設定を表す struct。
+/// `frugalos_segment` の設定。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FrugalosSegmentConfig {
     /// A configuration for a dispersed client.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,14 @@ frugalos:
       secs: 10
       nanos: 0
   mds:
+    commit_timeout_threshold: 20
+    large_proposal_queue_threshold: 250
+    large_leader_waiting_queue_threshold: 400
+    leader_waiting_timeout_threshold: 12
+    node_polling_interval:
+      secs: 0
+      nanos: 200000000
+    reelection_threshold: 48
     snapshot_threshold:
       start: 100
       end: 200
@@ -266,6 +274,12 @@ frugalos:
         expected.rpc_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 3333));
         expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);
         expected.rpc_server.tcp_write_timeout = Duration::from_secs(10);
+        expected.mds.commit_timeout_threshold = 20;
+        expected.mds.large_proposal_queue_threshold = 250;
+        expected.mds.large_leader_waiting_queue_threshold = 400;
+        expected.mds.leader_waiting_timeout_threshold = 12;
+        expected.mds.node_polling_interval = Duration::from_millis(200);
+        expected.mds.reelection_threshold = 48;
         expected.mds.snapshot_threshold = Range {
             start: 100,
             end: 200,


### PR DESCRIPTION
mds の node の設定を外部から与えられるようにした。https://github.com/frugalos/frugalos/issues/90 と https://github.com/frugalos/frugalos/issues/91 を解決する。

コードのリファクタリングは主目的ではないためこの PR ではそのままにした箇所がある。