### PR TITLE
Now PutAll rejects an incorrect iterator as input.

### DIFF
--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -882,7 +882,7 @@ mod tests {
     }
 
     #[test]
-    fn put_all_new_works() {
+    fn put_all_new_works() -> TestResult {
         let futures: Vec<BoxFuture<_>> = vec![];
         assert!(PutAll::new(futures.into_iter(), 2).is_err());
 
@@ -893,14 +893,18 @@ mod tests {
             Box::new(futures::future::ok(())),
             Box::new(futures::future::ok(())),
         ];
-        assert!(PutAll::new(futures.into_iter(), 2).is_ok());
+        let put = track!(PutAll::new(futures.into_iter(), 2))?;
+        assert!(wait(put).is_ok());
 
         let futures: Vec<BoxFuture<_>> = vec![
             Box::new(futures::future::ok(())),
             Box::new(futures::future::ok(())),
             Box::new(futures::future::ok(())),
         ];
-        assert!(PutAll::new(futures.into_iter(), 2).is_ok());
+        let put = track!(PutAll::new(futures.into_iter(), 2))?;
+        assert!(wait(put).is_ok());
+
+        Ok(())
     }
 
     #[test]

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -195,7 +195,11 @@ impl ReplicatedClient {
                 );
                 future
             });
-        Box::new(PutAll::new(futures, 1))
+        let put_all = match track!(PutAll::new(futures, 1)) {
+            Ok(put_all) => put_all,
+            Err(error) => return Box::new(futures::failed(error)),
+        };
+        Box::new(put_all)
     }
 }
 
@@ -259,16 +263,24 @@ pub struct PutAll {
     required_ok_count: usize,
 }
 impl PutAll {
-    pub fn new<I>(futures: I, required_ok_count: usize) -> Self
+    pub fn new<I>(futures: I, required_ok_count: usize) -> Result<Self>
     where
         I: Iterator<Item = BoxFuture<()>>,
     {
+        let (_, upper_bound) = futures.size_hint();
+        let len = track!(upper_bound.ok_or_else(
+            || ErrorKind::Invalid.cause("The upper bound of the given futures is unknown.")
+        ))?;
+        if len < required_ok_count {
+            let e = ErrorKind::Invalid.cause(format!("The length of the given futures is too short:  required_ok_count={}, futures.len={}", required_ok_count, len));
+            return Err(track!(Error::from(e)));
+        }
         let future = future::select_all(futures);
-        PutAll {
+        Ok(PutAll {
             future,
             ok_count: 0,
             required_ok_count,
-        }
+        })
     }
 }
 impl Future for PutAll {
@@ -547,7 +559,7 @@ impl Future for DispersedPut {
                             );
                             future
                         });
-                    Phase::B(PutAll::new(futures, self.data_fragments))
+                    Phase::B(track!(PutAll::new(futures, self.data_fragments))?)
                 }
                 Phase::B(()) => {
                     return Ok(Async::Ready(()));
@@ -870,25 +882,49 @@ mod tests {
     }
 
     #[test]
-    fn put_all_fails_correctly() {
+    fn put_all_new_works() {
+        let futures: Vec<BoxFuture<_>> = vec![];
+        assert!(PutAll::new(futures.into_iter(), 2).is_err());
+
+        let futures: Vec<BoxFuture<_>> = vec![Box::new(futures::future::ok(()))];
+        assert!(PutAll::new(futures.into_iter(), 2).is_err());
+
         let futures: Vec<BoxFuture<_>> = vec![
-            Box::new(futures::future::err(ErrorKind::Other.into())),
             Box::new(futures::future::ok(())),
-            Box::new(futures::future::err(ErrorKind::Other.into())),
+            Box::new(futures::future::ok(())),
         ];
-        let put = PutAll::new(futures.into_iter(), 2);
-        assert!(wait(put).is_err());
+        assert!(PutAll::new(futures.into_iter(), 2).is_ok());
+
+        let futures: Vec<BoxFuture<_>> = vec![
+            Box::new(futures::future::ok(())),
+            Box::new(futures::future::ok(())),
+            Box::new(futures::future::ok(())),
+        ];
+        assert!(PutAll::new(futures.into_iter(), 2).is_ok());
     }
 
     #[test]
-    fn put_all_fails_even_if_last_operation_succeeds() {
+    fn put_all_fails_correctly() -> TestResult {
+        let futures: Vec<BoxFuture<_>> = vec![
+            Box::new(futures::future::err(ErrorKind::Other.into())),
+            Box::new(futures::future::ok(())),
+            Box::new(futures::future::err(ErrorKind::Other.into())),
+        ];
+        let put = track!(PutAll::new(futures.into_iter(), 2))?;
+        assert!(wait(put).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn put_all_fails_even_if_last_operation_succeeds() -> TestResult {
         let futures: Vec<BoxFuture<_>> = vec![
             Box::new(futures::future::err(ErrorKind::Other.into())),
             Box::new(futures::future::err(ErrorKind::Other.into())),
             Box::new(futures::future::ok(())),
         ];
-        let put = PutAll::new(futures.into_iter(), 2);
+        let put = track!(PutAll::new(futures.into_iter(), 2))?;
         assert!(wait(put).is_err());
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
PutAll の引数の iterator が required_ok_count 未満の場合にエラーを返すようにする修正。