### PR TITLE
Rename FrugalosRpcServerConfig to FrugalosRpcClientConfig

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -66,7 +66,7 @@ impl FrugalosDaemon {
         .map_err(Error::from))?;
         let rpc_service = RpcServiceBuilder::new()
             .logger(logger.clone())
-            .channel_options(config.rpc_server.channel_options())
+            .channel_options(config.rpc_client.channel_options())
             .finish(executor.handle());
 
         let raft_service = frugalos_raft::Service::new(logger.clone(), &mut rpc_server_builder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,9 @@ pub struct FrugalosConfig {
     /// HTTP server 向けの設定。
     #[serde(default)]
     pub http_server: FrugalosHttpServerConfig,
-    /// RPC server 向けの設定。
+    /// RPC client 向けの設定。
     #[serde(default)]
-    pub rpc_server: FrugalosRpcServerConfig,
+    pub rpc_client: FrugalosRpcClientConfig,
     /// frugalos_mds 向けの設定。
     #[serde(default)]
     pub mds: frugalos_mds::FrugalosMdsConfig,
@@ -123,7 +123,7 @@ impl Default for FrugalosConfig {
             max_concurrent_logs: default_max_concurrent_logs(),
             daemon: Default::default(),
             http_server: Default::default(),
-            rpc_server: Default::default(),
+            rpc_client: Default::default(),
             mds: Default::default(),
             segment: Default::default(),
         }
@@ -176,9 +176,9 @@ impl Default for FrugalosHttpServerConfig {
     }
 }
 
-/// RPC server 向けの設定。
+/// RPC client 向けの設定。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct FrugalosRpcServerConfig {
+pub struct FrugalosRpcClientConfig {
     /// RPC の接続タイムアウト時間。
     #[serde(
         rename = "tcp_connect_timeout_millis",
@@ -196,7 +196,7 @@ pub struct FrugalosRpcServerConfig {
     pub tcp_write_timeout: Duration,
 }
 
-impl FrugalosRpcServerConfig {
+impl FrugalosRpcClientConfig {
     fn channel_options(&self) -> fibers_rpc::channel::ChannelOptions {
         let mut options = fibers_rpc::channel::ChannelOptions::default();
         options.tcp_connect_timeout = self.tcp_connect_timeout;
@@ -205,7 +205,7 @@ impl FrugalosRpcServerConfig {
     }
 }
 
-impl Default for FrugalosRpcServerConfig {
+impl Default for FrugalosRpcClientConfig {
     fn default() -> Self {
         Self {
             tcp_connect_timeout: default_tcp_connect_timeout(),
@@ -270,7 +270,7 @@ frugalos:
     stop_waiting_time_millis: 300
   http_server:
     bind_addr: "127.0.0.1:2222"
-  rpc_server:
+  rpc_client:
     tcp_connect_timeout_millis: 8000
     tcp_write_timeout_millis: 10000
   mds:
@@ -302,8 +302,8 @@ frugalos:
         expected.daemon.executor_threads = 3;
         expected.daemon.stop_waiting_time = Duration::from_millis(300);
         expected.http_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 2222));
-        expected.rpc_server.tcp_connect_timeout = Duration::from_secs(8);
-        expected.rpc_server.tcp_write_timeout = Duration::from_secs(10);
+        expected.rpc_client.tcp_connect_timeout = Duration::from_secs(8);
+        expected.rpc_client.tcp_write_timeout = Duration::from_secs(10);
         expected.mds.commit_timeout_threshold = 20;
         expected.mds.large_proposal_queue_threshold = 250;
         expected.mds.large_leader_waiting_queue_threshold = 400;

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,9 +257,9 @@ fn main() {
             &matches,
             &mut config.http_server
         )));
-        track_try_unwrap!(track_any_err!(set_rpc_server_config(
+        track_try_unwrap!(track_any_err!(set_rpc_client_config(
             &matches,
-            &mut config.rpc_server
+            &mut config.rpc_client
         )));
         track_try_unwrap!(track_any_err!(set_segment_config(
             &matches,
@@ -425,10 +425,10 @@ fn set_http_server_config(
     Ok(())
 }
 
-/// Sets configurations for a RPC server.
-fn set_rpc_server_config(
+/// Sets configurations for a RPC client.
+fn set_rpc_client_config(
     matches: &ArgMatches,
-    config: &mut frugalos::FrugalosRpcServerConfig,
+    config: &mut frugalos::FrugalosRpcClientConfig,
 ) -> Result<()> {
     if let Some(v) = matches.value_of("RPC_CONNECT_TIMEOUT_MILLIS") {
         config.tcp_connect_timeout = v


### PR DESCRIPTION
rpc client 向けの設定に server の設定名が付いており明らかにおかしいため直しました。