### PR TITLE
Parameterize CANNYLS_MAX_QUEUE_LEN and RPC_MAX_QUEUE_LEN

### DIFF
--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -65,6 +65,9 @@ pub struct FrugalosSegmentConfig {
     /// A configuration for a dispersed client.
     #[serde(default)]
     pub dispersed_client: config::DispersedClientConfig,
+    /// A configuration for a replicated client.
+    #[serde(default)]
+    pub replicated_client: config::ReplicatedClientConfig,
     /// A configuration for `MdsClient`.
     #[serde(default)]
     pub mds_client: config::MdsClientConfig,
@@ -74,6 +77,7 @@ impl Default for FrugalosSegmentConfig {
     fn default() -> Self {
         Self {
             dispersed_client: Default::default(),
+            replicated_client: Default::default(),
             mds_client: Default::default(),
         }
     }

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -223,6 +223,7 @@ pub mod tests {
                 ClientConfig {
                     cluster: self.cluster_config.clone(),
                     dispersed_client: Default::default(),
+                    replicated_client: Default::default(),
                     storage: self.make_dispersed_storage(),
                     mds: MdsClientConfig::default(),
                 },

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -58,6 +58,7 @@ impl Bucket {
                 members: Vec::new(),
             },
             dispersed_client: segment_config.dispersed_client.clone(),
+            replicated_client: segment_config.replicated_client.clone(),
             storage: storage_config.clone(),
             mds: segment_config.mds_client.clone(),
         };
@@ -83,6 +84,7 @@ impl Bucket {
         let segment_config = frugalos_segment::config::ClientConfig {
             cluster: frugalos_segment::config::ClusterConfig { members },
             dispersed_client: self.segment_config.dispersed_client.clone(),
+            replicated_client: self.segment_config.replicated_client.clone(),
             storage: self.storage_config.clone(),
             mds: self.segment_config.mds_client.clone(),
         };


### PR DESCRIPTION
`CANNYLS_MAX_QUEUE_LEN` と `RPC_MAX_QUEUE_LEN` を設定ファイルから指定できるようにする修正です。

## 設定例

```yaml
---
frugalos:
  segment:
    dispersed_client:
      cannyls_device_max_queue_len: 3
      cannyls_rpc_max_queue_len: 2
```