### PR TITLE
Improves frugalos_raft metrics

### DIFF
--- a/frugalos_config/src/cluster.rs
+++ b/frugalos_config/src/cluster.rs
@@ -87,7 +87,12 @@ pub fn make_rlog<P: AsRef<Path>, S: Spawn + Clone + Send + 'static>(
 
     // FIXME: パラメータ化
     let timer = frugalos_raft::Timer::new(Duration::from_secs(10), Duration::from_secs(35));
-    let storage = frugalos_raft::Storage::new(logger, node.local_id, device.handle());
+    let storage = frugalos_raft::Storage::new(
+        logger,
+        node.local_id,
+        device.handle(),
+        frugalos_raft::StorageMetrics::new(),
+    );
     let mailer = frugalos_raft::Mailer::new(spawner, rpc_service, None);
 
     let io = track!(RaftIo::new(raft_service, storage, mailer, timer))?;

--- a/frugalos_raft/src/lib.rs
+++ b/frugalos_raft/src/lib.rs
@@ -42,7 +42,7 @@ pub mod future_impls {
 pub use node::{LocalNodeId, NodeId};
 pub use raft_io::RaftIo;
 pub use rpc::{Mailer, RpcMetrics, Service, ServiceHandle};
-pub use storage::Storage;
+pub use storage::{Storage, StorageMetrics};
 pub use timer::Timer;
 
 mod node;

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -30,7 +30,6 @@ pub struct Service<S> {
     device_registry: DeviceRegistry,
     command_tx: mpsc::Sender<Command>,
     command_rx: mpsc::Receiver<Command>,
-    raft_metrics: frugalos_raft::RpcMetrics,
     mds_alive: bool,
     mds_config: FrugalosMdsConfig,
 }
@@ -61,7 +60,6 @@ where
             device_registry,
             command_tx,
             command_rx,
-            raft_metrics: frugalos_raft::RpcMetrics::new(),
             mds_alive: true,
             mds_config,
         })
@@ -108,7 +106,6 @@ where
                 let spawner = self.spawner.clone();
                 let rpc_service = self.rpc_service.clone();
                 let raft_service = self.raft_service.clone();
-                let raft_metrics = self.raft_metrics.clone();
                 let mds_config = self.mds_config.clone();
                 let mds_service = self.mds_service.handle();
                 let future = device
@@ -119,7 +116,6 @@ where
                             spawner,
                             rpc_service,
                             raft_service,
-                            raft_metrics,
                             &mds_config,
                             mds_service,
                             node_id,
@@ -209,7 +205,6 @@ impl SegmentNode {
         spawner: S,
         rpc_service: RpcServiceHandle,
         raft_service: frugalos_raft::ServiceHandle,
-        raft_metrics: frugalos_raft::RpcMetrics,
         mds_config: &FrugalosMdsConfig,
         mds_service: MdsHandle,
 
@@ -237,8 +232,17 @@ impl SegmentNode {
             Duration::from_millis(min_timeout),
             Duration::from_millis(max_timeout),
         );
-        let storage = frugalos_raft::Storage::new(logger.clone(), node_id.local_id, device.clone());
-        let mailer = frugalos_raft::Mailer::new(spawner, rpc_service.clone(), Some(raft_metrics));
+        let storage = frugalos_raft::Storage::new(
+            logger.clone(),
+            node_id.local_id,
+            device.clone(),
+            frugalos_raft::StorageMetrics::new(),
+        );
+        let mailer = frugalos_raft::Mailer::new(
+            spawner,
+            rpc_service.clone(),
+            Some(frugalos_raft::RpcMetrics::new()),
+        );
         let io = track!(frugalos_raft::RaftIo::new(
             raft_service,
             storage,


### PR DESCRIPTION
`frugalos_raft::storage` のメトリクスを集計する修正です。各処理にどのぐらい時間がかかっているかを計測したい意図があります。