### PR TITLE
Fix inappropriate wording about Japanese language

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation
 -------------
 
 - [Rustdoc](https://docs.rs/frugalos)
-- [Wiki (Japanese only)](https://github.com/frugalos/frugalos/wiki)
+- [Wiki (Japanese version only)](https://github.com/frugalos/frugalos/wiki)
 - [Real World Example in Niconico (used for recording live video streams)][niconico example]
 
 [niconico example]: https://dwango.github.io/articles/frugalos/


### PR DESCRIPTION
`Japanese only` sounds like only Japanese people are allowed to access. `Japanese version only` seems more accurate for this situation.
Reference: http://next49.hatenadiary.jp/entry/20140428/p1 (written in Japanse)