### PR TITLE
Remove a dangerous link

### DIFF
--- a/it/README.md
+++ b/it/README.md
@@ -146,3 +146,4 @@ Removing network clusters_frugalos_net
 
 - Pumba:
  - https://github.com/gaia-adm/pumba
+ - https://github.com/alexei-led/blog/blob/master/content/post/pumba_docker_chaos_testing.md

--- a/it/README.md
+++ b/it/README.md
@@ -145,5 +145,4 @@ Removing network clusters_frugalos_net
 -----
 
 - Pumba:
- - http://blog.terranillius.com/post/pumba_docker_chaos_testing/
  - https://github.com/gaia-adm/pumba


### PR DESCRIPTION
`blog.terranillius.com` now redirects to a random harmful page and therefore needs to be immediately removed.