### PR TITLE
Make it possible to clear raft logs once when frugalos starts

### DIFF
--- a/frugalos_raft/src/lib.rs
+++ b/frugalos_raft/src/lib.rs
@@ -42,7 +42,7 @@ pub mod future_impls {
 pub use node::{LocalNodeId, NodeId};
 pub use raft_io::RaftIo;
 pub use rpc::{Mailer, RpcMetrics, Service, ServiceHandle};
-pub use storage::{Storage, StorageMetrics};
+pub use storage::{ClearLog, Storage, StorageMetrics};
 pub use timer::Timer;
 
 mod node;

--- a/frugalos_raft/src/storage/log_prefix/load.rs
+++ b/frugalos_raft/src/storage/log_prefix/load.rs
@@ -38,7 +38,7 @@ impl Future for LoadLogPrefix {
     type Item = Option<LogPrefix>;
     type Error = Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        while let Async::Ready(phase) = self.phase.poll()? {
+        while let Async::Ready(phase) = track!(self.phase.poll())? {
             let next = match phase {
                 Phase::A(None) => {
                     info!(

--- a/frugalos_raft/src/storage/log_prefix/save.rs
+++ b/frugalos_raft/src/storage/log_prefix/save.rs
@@ -9,12 +9,11 @@ use std::env;
 use std::ops::Range;
 use std::time::Instant;
 
-use super::super::{into_box_future, BoxFuture, Event, Handle, Storage};
+use super::super::{into_box_future, BoxFuture, Event, Handle, Storage, StorageMetrics};
 use super::delete::{DeleteOldLogEntries, DeleteOldLogPrefixBytes};
 use super::load::LoadLogPrefixIndex;
 use protobuf;
 use util::Phase5;
-use StorageMetrics;
 
 fn max_lump_data_size() -> usize {
     env::var("RAFT_IO_MAX_LUMP_DATA_SIZE")

--- a/frugalos_raft/src/storage/log_suffix.rs
+++ b/frugalos_raft/src/storage/log_suffix.rs
@@ -24,6 +24,9 @@ pub struct LoadLogSuffix {
 }
 impl LoadLogSuffix {
     pub fn new(storage: &Storage) -> Self {
+        // ログの接尾部分を正しく読み出せる暗黙の前提条件として、ログ読み込みによりローカルバッファの
+        // ログの接尾部分の開始位置が適切に更新されている必要がある。
+        // つまり、ログの接頭辞部分を先に読み込んでおかなければならない。
         let head = storage.log_suffix.head;
         let handle = storage.handle.clone();
         info!(handle.logger, "[START] LoadLogSuffix: {}", dump!(head));

--- a/frugalos_raft/src/storage/mod.rs
+++ b/frugalos_raft/src/storage/mod.rs
@@ -463,9 +463,6 @@ fn make_histogram(builder: &mut HistogramBuilder) -> Histogram {
 }
 
 /// ログの接頭辞部分と接尾部分を削除する。
-///
-/// 接頭辞部分と接尾部分が削除されていれば、ログ削除直後にログを持っていないノードが
-/// リーダーに選ばれることはないため `Ballot` は削除しない。
 pub enum ClearLog {
     /// ログを削除する。
     DeleteLog(DeleteLog),

--- a/frugalos_raft/src/storage/mod.rs
+++ b/frugalos_raft/src/storage/mod.rs
@@ -1,7 +1,7 @@
 use cannyls;
 use cannyls::device::DeviceHandle;
 use fibers::sync::mpsc;
-use futures::{Async, Future, Stream};
+use futures::{Async, Future, Poll, Stream};
 use prometrics::metrics::{Histogram, HistogramBuilder, MetricBuilder};
 use raftlog::election::Ballot;
 use raftlog::log::{LogIndex, LogPosition, LogPrefix, LogSuffix};
@@ -13,7 +13,7 @@ use trackable::error::ErrorKindExt;
 use LocalNodeId;
 
 pub use self::ballot::{LoadBallot, SaveBallot};
-pub use self::log::{LoadLog, SaveLog};
+pub use self::log::{DeleteLog, LoadLog, SaveLog};
 pub use self::log_prefix::{LoadLogPrefix, SaveLogPrefix};
 pub use self::log_suffix::{LoadLogSuffix, SaveLogSuffix};
 
@@ -84,6 +84,14 @@ impl Storage {
         }
     }
 
+    /// 永続化されているログを削除する.
+    ///
+    /// 接頭辞部分と接尾部分の両方が削除対象となる. 不正なログが混入した時など異常事態に
+    /// 使うことを想定していて、通常はログを削除する必要はない.
+    pub(crate) fn delete_log(&mut self) -> DeleteLog {
+        DeleteLog::new(&self.handle, self.event_tx.clone(), self.node_id())
+    }
+
     pub(crate) fn logger(&self) -> Logger {
         self.handle.logger.clone()
     }
@@ -135,6 +143,9 @@ impl Storage {
             // 「終端が未指定」かつ「開始地点が0」は、ノード起動時の最初のログ読み込みを示している
             // => まずスナップショットのロードを試みる
             let future = log_prefix::LoadLogPrefix::new(self);
+            // ここでログの前半部分が読み込めなかった場合、ログの接尾部分の開始位置は 0 番目から
+            // 開始しているという暗黙の前提があるため、ログの接尾部分の開始位置が 0 番目の状態で
+            // `LoadLogSuffix` を生成しても接尾部分が正しく読み込める。
             let next = Some(log_suffix::LoadLogSuffix::new(self));
             log::LoadLogInner::LoadLogPrefix {
                 next,
@@ -221,6 +232,9 @@ impl Storage {
                 Event::LogSuffixLoaded(suffix) => {
                     track!(self.handle_log_suffix_loaded_event(suffix))?;
                 }
+                Event::LogSuffixDeleted => {
+                    track!(self.handle_log_suffix_deleted_event())?;
+                }
             }
         }
         Ok(())
@@ -260,6 +274,16 @@ impl Storage {
             dump!(suffix.head, suffix.entries.len())
         );
         self.log_suffix = suffix;
+        Ok(())
+    }
+    fn handle_log_suffix_deleted_event(&mut self) -> Result<()> {
+        // ログの接尾部分がストレージから削除されたので、バッファに反映する
+        info!(
+            self.handle.logger,
+            "Event::LogSuffixDeleted: {}",
+            dump!(self.log_suffix.head)
+        );
+        self.log_suffix = Default::default();
         Ok(())
     }
     fn append_to_local_buffer(&mut self, suffix: &LogSuffix) -> Result<()> {
@@ -313,9 +337,11 @@ pub(crate) struct Handle {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Event {
     LogPrefixUpdated { new_head: LogPosition },
     LogSuffixLoaded(LogSuffix),
+    LogSuffixDeleted,
 }
 
 type BoxFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
@@ -434,4 +460,41 @@ fn make_histogram(builder: &mut HistogramBuilder) -> Histogram {
         .bucket(50.0)
         .finish()
         .expect("Never fails")
+}
+
+/// ログの接頭辞部分と接尾部分を削除する。
+///
+/// 接頭辞部分と接尾部分が削除されていれば、ログ削除直後にログを持っていないノードが
+/// リーダーに選ばれることはないため `Ballot` は削除しない。
+pub enum ClearLog {
+    /// ログを削除する。
+    DeleteLog(DeleteLog),
+
+    /// ログの削除をスキップする。
+    Skip,
+}
+impl ClearLog {
+    /// ログを消去するためのインスタンスを生成する。
+    ///
+    /// ログ消去後は新たに `Storage` を生成して状態を初期化するのが安全で望ましいため、
+    /// 古い `Storage` の所有権を奪う。
+    pub fn new(mut storage: Storage) -> Self {
+        let future = storage.delete_log();
+        ClearLog::DeleteLog(future)
+    }
+
+    /// ログの削除をスキップする。
+    pub fn skip() -> Self {
+        ClearLog::Skip
+    }
+}
+impl Future for ClearLog {
+    type Item = ();
+    type Error = Error;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self {
+            ClearLog::DeleteLog(future) => Ok(track!(future.poll())?),
+            ClearLog::Skip => Ok(Async::Ready(())),
+        }
+    }
 }

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -101,10 +101,12 @@ where
 
     fn handle_command(&mut self, command: Command) {
         match command {
-            Command::AddNode(node_id, device, client, cluster) => {
+            Command::AddNode(node_id, device, client, cluster, config) => {
                 // TODO: error handling
                 let logger = self.logger.clone();
                 let logger0 = logger.clone();
+                let logger1 = logger.clone();
+                let local_id = node_id.local_id;
                 let spawner = self.spawner.clone();
                 let rpc_service = self.rpc_service.clone();
                 let raft_service = self.raft_service.clone();
@@ -112,6 +114,24 @@ where
                 let mds_service = self.mds_service.handle();
                 let future = device
                     .map_err(|e| track!(e))
+                    .and_then(move |device| {
+                        // raft のログが不正な状態になった場合に強制削除するための対応
+                        // https://github.com/frugalos/frugalos/issues/157
+                        // https://github.com/frugalos/raftlog/issues/18
+                        let logger = logger1.new(o!("node" => local_id.to_string()));
+                        let future = if config.discard_former_log {
+                            let storage = frugalos_raft::Storage::new(
+                                logger,
+                                local_id,
+                                device.clone(),
+                                frugalos_raft::StorageMetrics::new(),
+                            );
+                            frugalos_raft::ClearLog::new(storage)
+                        } else {
+                            frugalos_raft::ClearLog::skip()
+                        };
+                        future.map(|_| device).map_err(|e| track!(Error::from(e)))
+                    })
                     .and_then(move |device| {
                         track!(SegmentNode::new(
                             &logger0,
@@ -178,8 +198,13 @@ impl ServiceHandle {
         device: CreateDeviceHandle,
         client: Client,
         cluster: ClusterMembers,
+        // NOTE: "前回の状態"は raft だけに限らないので raft を意識しない
+        discard_former_state: bool,
     ) -> Result<()> {
-        let command = Command::AddNode(node_id, device, client.storage, cluster);
+        let raft_config = RaftConfig {
+            discard_former_log: discard_former_state,
+        };
+        let command = Command::AddNode(node_id, device, client.storage, cluster, raft_config);
         track!(self
             .command_tx
             .send(command,)
@@ -190,8 +215,20 @@ impl ServiceHandle {
 
 pub type CreateDeviceHandle = Box<Future<Item = DeviceHandle, Error = Error> + Send + 'static>;
 
-pub enum Command {
-    AddNode(NodeId, CreateDeviceHandle, StorageClient, ClusterMembers),
+/// Raft に関連する設定。
+struct RaftConfig {
+    /// true ならノード追加前に保存されていた Raft のログを破棄する。
+    discard_former_log: bool,
+}
+
+enum Command {
+    AddNode(
+        NodeId,
+        CreateDeviceHandle,
+        StorageClient,
+        ClusterMembers,
+        RaftConfig,
+    ),
 }
 
 struct SegmentNode {

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -161,6 +161,7 @@ pub mod tests {
                         ),
                         client,
                         cluster.clone(),
+                        false,
                     )
                     .unwrap();
             }

--- a/it/testsuites/raftlog_recovery.sh
+++ b/it/testsuites/raftlog_recovery.sh
@@ -1,0 +1,65 @@
+#! /bin/bash
+# 1 プロセスでクラスタを組んでいる場合に、適当に propose した後に raft のログを
+# 削除(かつ、成功)すればディスク上には PUT したデータが残っているがデータの位置
+# が分からなくなり GET ができなくなるという特性を妥当性の検証として利用。
+
+set -eux
+
+source $(cd $(dirname $0); pwd)/common.sh
+
+CLUSTER=single-node
+EXPECTED_TOTAL=100
+SLEEP_SECONDS=10
+
+#
+# Cleanups previous garbages
+#
+docker-compose -f it/clusters/${CLUSTER}.yml down
+sudo rm -rf /tmp/frugalos_it/
+
+#
+# Setups cluster
+#
+docker-compose -f it/clusters/${CLUSTER}.yml up -d
+mkdir -p ${WORK_DIR}
+sudo chmod 777 ${WORK_DIR}
+sleep 1
+curl -f http://frugalos01/v1/servers | tee $WORK_DIR/servers.json
+SERVERS=`jq 'map(.id) | .[]' /tmp/frugalos_it/servers.json | sed -e 's/"//g'`
+
+#
+# Setups devices
+#
+it/scripts/put_devices.sh 1 $SERVERS
+
+#
+# Setups buckets
+#
+it/scripts/put_buckets.sh 1 2
+curl http://frugalos01/v1/buckets
+
+#
+# Puts objects
+#
+it/scripts/gen_put_requests.sh frugalos01 live_archive_chunk 1 $EXPECTED_TOTAL $WORK_DIR/req.json
+sleep $SLEEP_SECONDS
+hb run -i $WORK_DIR/req.json | hb summary
+
+#
+# ログを削除 => GET が 404 になる
+#
+docker-compose -f it/clusters/single-node.yml exec frugalos01 sh -c 'touch /var/lib/frugalos/recovery.yml'
+docker-compose -f it/clusters/${CLUSTER}.yml restart frugalos01
+sleep $SLEEP_SECONDS
+it/scripts/http_requests.sh GET 404 $WORK_DIR/req.json $WORK_DIR/res.json $EXPECTED_TOTAL
+
+#
+# raft のログを削除した後に PUT => GET ができることを確認
+#
+hb run -i $WORK_DIR/req.json | hb summary
+it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json $EXPECTED_TOTAL
+
+#
+# Cleanups cluster
+#
+docker-compose -f it/clusters/${CLUSTER}.yml down

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use trackable::error::ErrorKindExt;
 
 use config_server::ConfigServer;
+use recovery::prepare_recovery;
 use rpc_server::RpcServer;
 use server::{spawn_report_spans_thread, Server};
 use service;
@@ -52,6 +53,8 @@ impl FrugalosDaemon {
             slog::Duplicate::new(logger.clone(), track!(LogMetrics::new())?).fuse(),
             o!(),
         );
+
+        let recovery_request = track!(prepare_recovery(&logger, &data_dir))?;
 
         let server = track!(frugalos_config::cluster::load_local_server_info(&data_dir))?;
 
@@ -99,6 +102,7 @@ impl FrugalosDaemon {
             rpc_service.handle(),
             config.mds,
             config.segment,
+            recovery_request,
             tracer.clone(),
         ))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ mod codec;
 mod config_server;
 mod error;
 mod http;
+mod recovery;
 mod rpc_server;
 mod server;
 mod service;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1,0 +1,61 @@
+//! 障害からの復旧手順を提供する crate。
+//!
+//! 個別の復旧処理(raftのログ削除etc)はその他の crate 内で実装されている。
+//!
+//! ファイルを使ったリカバリー方式の意図については以下の URL を参照:
+//! - https://github.com/frugalos/frugalos/issues/157
+
+use slog::Logger;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use {Error, Result};
+
+// 未完了の設定ファイル名
+// NOTE: 設定ファイルに今後設定値を記述していけるよう YAML にしておく。
+const RECOVERY_FILE_NAME: &str = "recovery.yml";
+
+// 完了済みの設定ファイル名
+const COMPLETED_RECOVERY_FILE_NAME: &str = "recovery.done";
+
+/// 起動時に必要なリカバリー要求を表す。
+pub struct RecoveryRequest;
+
+/// リカバリー処理の準備をする。
+///
+/// この関数呼び出しの副作用でリカバリー要求のクリアが発生するため、2回目以降の呼び出しは無視される。
+/// (リカバリー処理を複数回行う必要性もない。)
+///
+/// 実際のリカバリー処理の成否によらずリカバリー要求がクリアされてしまうため、やり直しをしたい場合は
+/// 再度ファイルの配置をする必要がある。
+pub fn prepare_recovery<P: AsRef<Path>>(
+    logger: &Logger,
+    data_dir: P,
+) -> Result<Option<RecoveryRequest>> {
+    let src = data_dir.as_ref().join(RECOVERY_FILE_NAME);
+    let dest = data_dir.as_ref().join(COMPLETED_RECOVERY_FILE_NAME);
+
+    // atomic に処理したいため、io::ErrorKind::NotFound を許容し Ok 扱いにする。
+    match fs::rename(&src, &dest) {
+        Ok(()) => {
+            info!(
+                logger,
+                "Rename the recovery file: src={:?}, dest={:?}", src, dest
+            );
+            // 現時点では要求の有無だけを表現したい、かつ、明瞭性のために型を用意したいためフィールドなしの struct を返す。
+            Ok(Some(RecoveryRequest))
+        }
+        Err(e) => {
+            if let io::ErrorKind::NotFound = e.kind() {
+                info!(
+                    logger,
+                    "Skipped recovery process because the recovery file is not found.: src={:?}, dest={:?}", src, dest
+                );
+                Ok(None)
+            } else {
+                Err(track!(Error::from(e)))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 解決したいこと

(バグなどにより) raft のログに不正なログが保存されてしまった場合に、device に紐付いているファイルを削除しない限り raft node  が起動時に stop してしまう問題を回避したい。

## 詳細

意図と概要は https://github.com/frugalos/frugalos/issues/157 を参照。

## TODO

- [x] ログ削除のテストを追加