### PR TITLE
Remove unused imports && rename clippy lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rust:
 
 before_script:
   - rustup component add clippy-preview
+  - cargo clippy --version
 
 script:
   - cargo test --all

--- a/frugalos_mds/src/machine.rs
+++ b/frugalos_mds/src/machine.rs
@@ -94,8 +94,6 @@ impl Machine {
         &mut self,
         object_version: ObjectVersion,
     ) -> Result<Option<ObjectVersion>> {
-        use std::string::String;
-
         let owner_id: Option<Vec<u8>> = self
             .id_to_version
             .iter()

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -246,7 +246,7 @@ mod tests {
 
         // Deletes all fragments the dispersed device.
         for (_node_id, _device_id, device_handle) in members.clone() {
-            let mut result = wait(
+            let result = wait(
                 device_handle
                     .request()
                     .list()

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use frugalos::{Error, ErrorKind, Result};
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn main() {
     let rpc_server_bind_addr = default_rpc_server_bind_addr();
     let long_version = track_try_unwrap!(make_long_version());

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,8 @@ use frugalos::{Error, ErrorKind, Result};
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[allow(clippy::cognitive_complexity)]
+// See https://github.com/frugalos/frugalos/pull/161
+#[allow(renamed_and_removed_lints, clippy::cyclomatic_complexity, clippy::cognitive_complexity)]
 fn main() {
     let rpc_server_bind_addr = default_rpc_server_bind_addr();
     let long_version = track_try_unwrap!(make_long_version());

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,11 @@ use frugalos::{Error, ErrorKind, Result};
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 // See https://github.com/frugalos/frugalos/pull/161
-#[allow(renamed_and_removed_lints, clippy::cyclomatic_complexity, clippy::cognitive_complexity)]
+#[allow(
+    renamed_and_removed_lints,
+    clippy::cyclomatic_complexity,
+    clippy::cognitive_complexity
+)]
 fn main() {
     let rpc_server_bind_addr = default_rpc_server_bind_addr();
     let long_version = track_try_unwrap!(make_long_version());

--- a/src/server.rs
+++ b/src/server.rs
@@ -600,8 +600,6 @@ impl HandleRequest for JemallocStats {
     type Reply = Reply<Self::ResBody>;
 
     fn handle_request(&self, _req: Req<Self::ReqBody>) -> Self::Reply {
-        use jemalloc_ctl;
-
         // many statistics are cached and only updated when the epoch is advanced.
         let _ = jemalloc_ctl::epoch();
 


### PR DESCRIPTION
This PR addresses two issues:
- the most recent rust compiler (`rustc 1.35.0 (3c235d560 2019-05-20)`) complains about unused imports. (Reference: https://travis-ci.org/frugalos/frugalos/jobs/536732406)
- a clippy lint's name was changed: `clippy::cyclomatic_complexity` -> `clippy::cognitive_complexity`. Because rustc 1.31.0 uses the former while the latest stable uses the latter, `allow(renamed_and_removed_lints)` is added to deal with this discrepancy.

In addition to this, some minor changes are made.