### PR TITLE
clippy-preview -> clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
   - nightly
 
 before_script:
-  - rustup component add clippy-preview
+  - rustup component add clippy
   - cargo clippy --version
 
 script:


### PR DESCRIPTION
Stop using the old name `clippy-preview` and use the new name `clippy` instead.