### PR TITLE
Add metrics that count success/failure of repairing

### DIFF
--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -95,8 +95,6 @@ impl Synchronizer {
                 .expect("metric should be well-formed"),
             repairs_durations_seconds: metric_builder
                 .histogram("repairs_durations_seconds")
-                .bucket(0.0001)
-                .bucket(0.0005)
                 .bucket(0.001)
                 .bucket(0.005)
                 .bucket(0.01)

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -66,32 +66,32 @@ impl Synchronizer {
                 .counter("enqueued_items")
                 .label("type", "repair")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
             enqueued_delete: metric_builder
                 .counter("enqueued_items")
                 .label("type", "delete")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
             dequeued_repair: metric_builder
                 .counter("dequeued_items")
                 .label("type", "repair")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
             dequeued_delete: metric_builder
                 .counter("dequeued_items")
                 .label("type", "delete")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
             repairs_success_total: metric_builder
                 .counter("repairs_success_total")
                 .label("type", "repair")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
             repairs_failure_total: metric_builder
                 .counter("repairs_failure_total")
                 .label("type", "repair")
                 .finish()
-                .unwrap(),
+                .expect("metric should be well-formed"),
         }
     }
     pub fn handle_event(&mut self, event: &Event) {

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -7,11 +7,11 @@ use frugalos_mds::Event;
 use frugalos_raft::NodeId;
 use futures::{Async, Future, Poll};
 use libfrugalos::entity::object::ObjectVersion;
-use prometrics::metrics::{Counter, MetricBuilder};
+use prometrics::metrics::{Counter, Histogram, MetricBuilder};
 use slog::Logger;
 use std::cmp::{self, Reverse};
 use std::collections::{BTreeSet, BinaryHeap};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use client::storage::{GetFragment, MaybeFragment, StorageClient};
 use config;
@@ -39,6 +39,7 @@ pub struct Synchronizer {
     dequeued_delete: Counter,
     repairs_success_total: Counter,
     repairs_failure_total: Counter,
+    repairs_durations_seconds: Histogram,
 }
 impl Synchronizer {
     pub fn new(
@@ -89,6 +90,22 @@ impl Synchronizer {
                 .expect("metric should be well-formed"),
             repairs_failure_total: metric_builder
                 .counter("repairs_failure_total")
+                .label("type", "repair")
+                .finish()
+                .expect("metric should be well-formed"),
+            repairs_durations_seconds: metric_builder
+                .histogram("repairs_durations_seconds")
+                .bucket(0.0001)
+                .bucket(0.0005)
+                .bucket(0.001)
+                .bucket(0.005)
+                .bucket(0.01)
+                .bucket(0.05)
+                .bucket(0.1)
+                .bucket(0.5)
+                .bucket(1.0)
+                .bucket(5.0)
+                .bucket(10.0)
                 .label("type", "repair")
                 .finish()
                 .expect("metric should be well-formed"),
@@ -327,8 +344,10 @@ struct RepairContent {
     version: ObjectVersion,
     client: StorageClient,
     device: DeviceHandle,
+    started_at: Instant,
     repairs_success_total: Counter,
     repairs_failure_total: Counter,
+    repairs_durations_seconds: Histogram,
     phase: Phase3<BoxFuture<Option<LumpHeader>>, GetFragment, BoxFuture<bool>>,
 }
 impl RepairContent {
@@ -337,8 +356,10 @@ impl RepairContent {
         let device = synchronizer.device.clone();
         let node_id = synchronizer.node_id;
         let lump_id = config::make_lump_id(&node_id, version);
+        let started_at = Instant::now();
         let repairs_success_total = synchronizer.repairs_success_total.clone();
         let repairs_failure_total = synchronizer.repairs_failure_total.clone();
+        let repairs_durations_seconds = synchronizer.repairs_durations_seconds.clone();
         debug!(
             logger,
             "Starts checking content: version={:?}, lump_id={:?}", version, lump_id
@@ -352,8 +373,10 @@ impl RepairContent {
             version,
             client: synchronizer.client.clone(),
             device,
+            started_at,
             repairs_success_total,
             repairs_failure_total,
+            repairs_durations_seconds,
             phase,
         }
     }
@@ -418,6 +441,9 @@ impl Future for RepairContent {
                         "Completed repairing content: {:?}", self.version
                     );
                     self.repairs_success_total.increment();
+                    let elapsed =
+                        prometrics::timestamp::duration_to_seconds(self.started_at.elapsed());
+                    self.repairs_durations_seconds.observe(elapsed);
                     return Ok(Async::Ready(()));
                 }
             };


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

 - [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

 ## Description of changes

 ### Behavior
frugalos starts to expose two metrics: `frugalos_synchronizer_repairs_success_total`, `frugalos_synchronizer_repairs_failure_total` and `frugalos_synchronizer_repairs_durations_seconds_*`.

 ### Purpose
To track how many of repair requests succeeded and failed.

 ## Checklists

 - [x] I have run `cargo fmt --all`.