### PR TITLE
Apply clippy also to test code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - cargo test --all
-  - cargo clippy --all
+  - cargo clippy --all --all-targets
 
 matrix:
   allow_failures:

--- a/frugalos_core/src/serde_ext.rs
+++ b/frugalos_core/src/serde_ext.rs
@@ -39,14 +39,14 @@ mod tests {
         assert_eq!(10, duration_millis::to_millis(&Duration::from_millis(10)));
         assert_eq!(999, duration_millis::to_millis(&Duration::from_millis(999)));
         assert_eq!(0, duration_millis::to_millis(&Duration::from_nanos(3000)));
-        assert_eq!(0, duration_millis::to_millis(&Duration::from_nanos(999999)));
+        assert_eq!(0, duration_millis::to_millis(&Duration::from_nanos(999_999)));
         assert_eq!(
             1,
-            duration_millis::to_millis(&Duration::from_nanos(1000000))
+            duration_millis::to_millis(&Duration::from_nanos(1_000_000))
         );
         assert_eq!(
             1,
-            duration_millis::to_millis(&Duration::from_nanos(1000001))
+            duration_millis::to_millis(&Duration::from_nanos(1_000_001))
         );
         assert_eq!(1000, duration_millis::to_millis(&Duration::from_secs(1)));
     }

--- a/frugalos_mds/src/machine.rs
+++ b/frugalos_mds/src/machine.rs
@@ -214,6 +214,7 @@ mod tests {
     }
 
     fn make_object_id(id: usize, kind: MetadataKind) -> ObjectId {
+        #[allow(clippy::identity_conversion)]
         match kind {
             MetadataKind::MUSIC => ObjectId::from(format!("music:metadata:{}", id)),
             MetadataKind::LYRIC => ObjectId::from(format!("lyric:metadata:{}", id)),

--- a/frugalos_mds/src/node/handle.rs
+++ b/frugalos_mds/src/node/handle.rs
@@ -230,7 +230,8 @@ mod tests {
                 .delete_by_prefix(ObjectPrefix("chunk".to_owned()))
                 .and_then(move |summary| {
                     assert_eq!(summary.total, 3);
-                    Ok(handle.stop())
+                    handle.stop();
+                    Ok(())
                 })
                 .map_err(|e| {
                     let _ = track!(e);

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -266,10 +266,12 @@ mod tests {
                 ObjectPrefix("abc".to_owned()),
                 monitored,
             );
-            Ok(proposal.notify_committed(&[ObjectVersion(1)]))
+            proposal.notify_committed(&[ObjectVersion(1)]);
+            Ok(())
         }));
 
         let summary = track!(fibers_global::execute(monitor))?;
-        Ok(assert_eq!(summary.total, 1))
+        assert_eq!(summary.total, 1);
+        Ok(())
     }
 }

--- a/frugalos_raft/src/storage/log_prefix/delete.rs
+++ b/frugalos_raft/src/storage/log_prefix/delete.rs
@@ -159,7 +159,7 @@ mod tests {
         let mut system = new_system();
         let leader = system.select_leader()?;
         let proposals = test_util::make_proposals(proposal_size);
-        let _ = system.bulk_propose(leader, proposals)?;
+        system.bulk_propose(leader, proposals)?;
 
         f((system, leader))
     }

--- a/frugalos_raft/src/test_util.rs
+++ b/frugalos_raft/src/test_util.rs
@@ -136,7 +136,7 @@ impl System {
     }
 
     pub fn get_handle(&self, node: NodeIndex) -> Option<Handle> {
-        self.handles.get(node).map(|handle| handle.clone())
+        self.handles.get(node).cloned()
     }
 
     pub fn to_log_entry_lump_id(&self, node: NodeIndex, index: LogIndex) -> Option<LumpId> {

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -895,7 +895,7 @@ mod tests {
         version: ObjectVersion,
     ) -> usize {
         config
-            .candidates(version.clone())
+            .candidates(version)
             .position(|candidate| *candidate == member)
             .unwrap()
     }
@@ -964,8 +964,8 @@ mod tests {
         let version = ObjectVersion(1);
         let expected = vec![0x03];
 
-        let _ = wait(storage_client.clone().put(
-            version.clone(),
+        wait(storage_client.clone().put(
+            version,
             expected.clone(),
             Deadline::Infinity,
             Span::inactive().handle(),
@@ -1006,12 +1006,12 @@ mod tests {
                     node: node_id,
                     device: device_id.clone()
                 },
-                version.clone()
+                version
             ) < system.fragments() as usize
         );
 
-        let _ = wait(storage_client.clone().put(
-            version.clone(),
+        wait(storage_client.clone().put(
+            version,
             expected.clone(),
             Deadline::Infinity,
             Span::inactive().handle(),
@@ -1020,11 +1020,11 @@ mod tests {
         let result = wait(
             storage_client
                 .clone()
-                .get_fragment(node_id.clone(), version.clone()),
+                .get_fragment(node_id, version),
         )?;
 
         if let MaybeFragment::Fragment(content) = result {
-            assert!(content.len() > 0);
+            assert!(!content.is_empty());
             return Ok(());
         }
 
@@ -1057,12 +1057,12 @@ mod tests {
                     node: node_id,
                     device: device_id.clone()
                 },
-                version.clone()
+                version
             ) >= system.fragments() as usize
         );
 
-        let _ = wait(storage_client.clone().put(
-            version.clone(),
+        wait(storage_client.clone().put(
+            version,
             expected.clone(),
             Deadline::Infinity,
             Span::inactive().handle(),
@@ -1071,7 +1071,7 @@ mod tests {
         let result = wait(
             storage_client
                 .clone()
-                .get_fragment(node_id.clone(), version.clone()),
+                .get_fragment(node_id, version),
         )?;
 
         assert_eq!(result, MaybeFragment::NotParticipant);

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -425,7 +425,7 @@ mod tests {
         let version = ObjectVersion(1);
         let cluster = make_cluster(cluster_size);
         let candidates = cluster
-            .candidates(version.clone())
+            .candidates(version)
             .cloned()
             .collect::<Vec<_>>();
         let participants = Participants::dispersed(&candidates, fragments);

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(participants.len(), fragments as usize);
 
         for (i, device, is_participant) in matrix {
-            let member = candidates.get(i as usize).unwrap();
+            let member = &candidates[i as usize];
 
             assert_eq!(member.device, device);
             assert_eq!(
@@ -458,7 +458,7 @@ mod tests {
         ];
 
         for (i, expected_spares) in matrix {
-            let node_id = candidates.get(i).unwrap().node;
+            let node_id = candidates[i].node;
 
             assert_eq!(
                 expected_spares,

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -42,6 +42,7 @@ pub mod tests {
     /// Make a frugalos segment where there are `segment_size`-nodes.
     ///
     /// This method needs `segment_size >= system.fragments()`.
+    #[allow(clippy::type_complexity)]
     pub fn setup_system(
         system: &mut System,
         segment_size: usize,
@@ -143,7 +144,7 @@ pub mod tests {
         /// Registers all the nodes in the `members`.
         fn register_nodes(
             &mut self,
-            members: &Vec<(NodeId, DeviceId, DeviceHandle)>,
+            members: &[(NodeId, DeviceId, DeviceHandle)],
         ) -> Result<()> {
             let cluster: ClusterMembers = self
                 .cluster_config
@@ -178,7 +179,7 @@ pub mod tests {
 
             for member in &members {
                 self.cluster_config.members.push(ClusterMember {
-                    node: member.0.clone(),
+                    node: member.0,
                     device: member.1.clone(),
                 });
             }

--- a/frugalos_segment/src/test_util.rs
+++ b/frugalos_segment/src/test_util.rs
@@ -171,6 +171,7 @@ pub mod tests {
         }
 
         /// Boots this cluster with the given members.
+        #[allow(clippy::needless_pass_by_value)]
         pub fn boot(&mut self, members: Vec<(NodeId, DeviceId, DeviceHandle)>) -> Result<Client> {
             // at least one cluster member is required
             if members.is_empty() {


### PR DESCRIPTION
Closes https://github.com/frugalos/frugalos/issues/169.
`cargo clippy --all --all-targets` will be run on CI instead of `cargo clippy --all`. By this, code marked as `#[test]` will also be checked.