### PR TITLE
Reverts meaningless changes in PR #88

### DIFF
--- a/frugalos_mds/src/node/node.rs
+++ b/frugalos_mds/src/node/node.rs
@@ -462,10 +462,6 @@ impl Node {
             Request::Stop => {
                 if self.phase == Phase::Running {
                     info!(self.logger, "Starts stopping the node");
-                    unsafe {
-                        self.rlog.io_mut().stop();
-                    }
-                    self.start_reelection();
                     match track!(self.take_snapshot()) {
                         Err(e) => {
                             error!(self.logger, "Cannot take snapshot: {}", e);

--- a/frugalos_raft/src/raft_io.rs
+++ b/frugalos_raft/src/raft_io.rs
@@ -16,10 +16,7 @@ pub struct RaftIo {
     node_id: LocalNodeId,
     service: ServiceHandle,
     storage: Storage,
-    /// A `Mailer`. This variable becomes `None` once a stop request arrives.
-    mailer: Option<Mailer>,
-    /// Remaining messages which are already received before stopping.
-    remaining_messages: Vec<Message>,
+    mailer: Mailer,
     timer: Timer,
 }
 impl RaftIo {
@@ -37,20 +34,9 @@ impl RaftIo {
             node_id,
             service,
             storage,
-            mailer: Some(mailer),
-            remaining_messages: Vec::new(),
+            mailer,
             timer,
         })
-    }
-    /// Stops this `RaftIo`.
-    pub fn stop(&mut self) {
-        if let Some(ref mut mailer) = self.mailer {
-            while let Ok(Some(message)) = mailer.try_recv_message() {
-                self.remaining_messages.push(message);
-            }
-        }
-        // Drops a contained mailer to encourage a leader election using the timeout mechanism of Raft.
-        self.mailer = None;
     }
 }
 impl Io for RaftIo {
@@ -60,17 +46,9 @@ impl Io for RaftIo {
     type LoadLog = storage::LoadLog;
     type Timeout = Timeout;
     fn try_recv_message(&mut self) -> Result<Option<Message>> {
-        if let Some(message) = self.remaining_messages.pop() {
-            return Ok(Some(message));
-        }
-
-        if let Some(ref mut mailer) = self.mailer {
-            return mailer
-                .try_recv_message()
-                .map_err(|e| ErrorKind::Other.takes_over(e).into());
-        }
-
-        Ok(None)
+        self.mailer
+            .try_recv_message()
+            .map_err(|e| ErrorKind::Other.takes_over(e).into())
     }
     fn send_message(&mut self, message: Message) {
         let node = match message.header().destination.as_str().parse() {
@@ -80,9 +58,7 @@ impl Io for RaftIo {
             }
             Ok(id) => id,
         };
-        if let Some(ref mut mailer) = self.mailer {
-            mailer.send_message(&node, message);
-        }
+        self.mailer.send_message(&node, message);
     }
     fn save_ballot(&mut self, ballot: Ballot) -> Self::SaveBallot {
         self.storage.save_ballot(ballot)


### PR DESCRIPTION
#88 で入れた変更の内、`frugalos_mds::Node` に関連する変更を revert する変更です。revert する対象の変更を入れた理由は #88 を参照してください。

revert する理由は、

- 期待した効果がなかった
- プロセス停止時に HTTP GET/PUT のレイテンシを悪化させた

ためです。