### PR TITLE
[WIP] Add metrics related to `CollectFragments`.

### DIFF
--- a/frugalos_segment/src/metrics.rs
+++ b/frugalos_segment/src/metrics.rs
@@ -34,14 +34,54 @@ impl PutAllMetrics {
 }
 
 #[derive(Debug, Clone)]
+pub struct CollectFragmentsMetrics {
+    pub(crate) failures_total: Counter,
+    pub(crate) corrupted_total: Counter,
+    pub(crate) timeout_total: Counter,
+}
+
+impl CollectFragmentsMetrics {
+    pub(crate) fn new() -> Result<Self> {
+        let failures_total = track!(CounterBuilder::new("collect_fragment_failures_total")
+            .namespace("frugalos")
+            .subsystem("segment")
+            .help("Number of failures of collecting fragments")
+            .default_registry()
+            .finish())?;
+        let corrupted_total = track!(CounterBuilder::new("collect_fragment_corrupted_total")
+            .namespace("frugalos")
+            .subsystem("segment")
+            .help("Number of corrupted fragments")
+            .default_registry()
+            .finish())?;
+        let timeout_total = track!(CounterBuilder::new("collect_fragment_timeout_total")
+            .namespace("frugalos")
+            .subsystem("segment")
+            .help("Number of timeout fragments")
+            .default_registry()
+            .finish())?;
+        Ok(Self {
+            failures_total,
+            corrupted_total,
+            timeout_total,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DispersedClientMetrics {
     pub(crate) put_all: PutAllMetrics,
+    pub(crate) collect_fragments: CollectFragmentsMetrics,
 }
 
 impl DispersedClientMetrics {
     pub fn new() -> Result<Self> {
         let put_all = track!(PutAllMetrics::new("dispersed_client"))?;
-        Ok(DispersedClientMetrics { put_all })
+        let collect_fragments = track!(CollectFragmentsMetrics::new())?;
+        Ok(DispersedClientMetrics {
+            put_all,
+            collect_fragments,
+        })
     }
 }
 


### PR DESCRIPTION
This PR resolves https://github.com/frugalos/frugalos/issues/137.

I've added the following metrics:

- failures_total: the total number of failures
- corrupted_total: the total number of corrupted fragments
- timeout_total: the total number of timeout