### PR TITLE
Replace bare traits with dyn Traits

### DIFF
--- a/frugalos_core/src/serde_ext.rs
+++ b/frugalos_core/src/serde_ext.rs
@@ -67,7 +67,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_and_deserialize_work() -> Result<(), Box<std::error::Error>> {
+    fn serialize_and_deserialize_work() -> Result<(), Box<dyn std::error::Error>> {
         let test: TestStruct = TestStruct {
             duration: Duration::from_millis(42),
             default_duration: default_duration(),
@@ -81,7 +81,7 @@ mod tests {
     }
 
     #[test]
-    fn default_and_deserialize_work() -> Result<(), Box<std::error::Error>> {
+    fn default_and_deserialize_work() -> Result<(), Box<dyn std::error::Error>> {
         let yaml = r#"---
 duration: 24
 "#;

--- a/frugalos_raft/src/storage/mod.rs
+++ b/frugalos_raft/src/storage/mod.rs
@@ -318,7 +318,7 @@ pub(crate) enum Event {
     LogSuffixLoaded(LogSuffix),
 }
 
-type BoxFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+type BoxFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 fn into_box_future<F>(future: F) -> BoxFuture<F::Item>
 where

--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -333,15 +333,17 @@ pub struct Request<F, V> {
     parent: SpanHandle,
     peer: Option<NodeId>,
     timeout: RequestTimeout,
-    future:
-        Option<Box<Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>>,
+    future: Option<
+        Box<dyn Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>,
+    >,
 }
 impl<F, V> Request<F, V>
 where
     V: Send + 'static,
     F: Fn(
         RaftMdsClient,
-    ) -> Box<Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>,
+    )
+        -> Box<dyn Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>,
 {
     pub fn new(client: MdsClient, parent: SpanHandle, kind: RequestKind, request: F) -> Self {
         let max_retry = client.max_retry();
@@ -393,7 +395,8 @@ impl<F, V> Future for Request<F, V>
 where
     F: Fn(
         RaftMdsClient,
-    ) -> Box<Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>,
+    )
+        -> Box<dyn Future<Item = (Option<RemoteNodeId>, V), Error = MdsError> + Send + 'static>,
     V: Send + 'static,
 {
     type Item = V;

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -31,7 +31,7 @@ use metrics::{DispersedClientMetrics, PutAllMetrics, ReplicatedClientMetrics};
 use util::Phase;
 use {Error, ErrorKind, ObjectValue, Result};
 
-type BoxFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+type BoxFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 #[derive(Clone)]
 pub enum StorageClient {

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -188,7 +188,7 @@ impl ServiceHandle {
     }
 }
 
-pub type CreateDeviceHandle = Box<Future<Item = DeviceHandle, Error = Error> + Send + 'static>;
+pub type CreateDeviceHandle = Box<dyn Future<Item = DeviceHandle, Error = Error> + Send + 'static>;
 
 pub enum Command {
     AddNode(NodeId, CreateDeviceHandle, StorageClient, ClusterMembers),

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -21,7 +21,7 @@ use Error;
 const MAX_TIMEOUT_SECONDS: u64 = 60;
 const DELETE_CONCURRENCY: usize = 16;
 
-type BoxFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+type BoxFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 // TODO: 起動直後の確認は`device.list()`の結果を使った方が効率的
 pub struct Synchronizer {

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,7 +20,7 @@ use trackable::error::ErrorKindExt;
 use bucket::Bucket;
 use {Error, ErrorKind};
 
-type BoxFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+type BoxFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 #[derive(Clone)]
 pub struct FrugalosClient {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes
Use [`dyn Trait`](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html) syntax. In the current _beta_ compiler (`rustc 1.37.0-beta.2 (74e5a0d47 2019-07-08)`) doesn't allow the bare trait (`Trait`) syntax. This PR replaces all bare trait syntaxes with `dyn Trait` syntaxes.

You can make the stable rust (`1.36.0 (a53f9df32 2019-07-03)`) emit these errors by:
```
cargo clippy --all --all-targets -- -W bare_trait_objects
```
### Behavior
Nothing changes in behavior.
### Purpose
To follow the latest standard of Rust.

## Checklists

- [x] I have run `cargo fmt --all`.