### PR TITLE
Add git_ref build argument to frugalos-build

### DIFF
--- a/docker/frugalos-build/Dockerfile
+++ b/docker/frugalos-build/Dockerfile
@@ -17,5 +17,7 @@ ENV PATH $PATH:/root/.cargo/bin
 ##
 ## Frugalosをビルド
 ##
-RUN git clone https://github.com/frugalos/frugalos.git
+## ビルド対象の git のブランチ/コミットIDを指定する
+ARG git_ref=master
+RUN git clone https://github.com/frugalos/frugalos.git && cd frugalos && git checkout $git_ref
 RUN cd frugalos && cargo build --release --all


### PR DESCRIPTION
## Types of changes

Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes

### Behavior

See https://github.com/frugalos/frugalos/wiki/Build-a-binary-with-Docker.

An example:

```console
$ docker build -t frugalos-build --build-arg git_ref=bump-version-0.13.0 docker/frugalos-build
```

### Purpose

To specify which branch should be used when build a frugalos binary.

## Checklists

- [x] I have run `cargo fmt --all`.