### PR TITLE
Waits for a device when deleting raft logs

### DIFF
--- a/frugalos_raft/src/storage/log.rs
+++ b/frugalos_raft/src/storage/log.rs
@@ -167,6 +167,7 @@ impl DeleteLog {
                 .device
                 .request()
                 .deadline(Deadline::Infinity)
+                .wait_for_running()
                 .delete_range(node.to_available_lump_id_range())
                 .map(|_| ()),
         );


### PR DESCRIPTION
## Types of changes
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes

### Behavior

Waits for the completion of starting devices before deleting raft logs.

### Purpose

To fix the bug introduced by #158. See #188 for more details.

## Checklists

- [x] I have run `cargo fmt --all`.