### PR TITLE
Returns Async::Ready(()) when frugalos stops

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -233,7 +233,7 @@ impl Future for DaemonRunner {
             for reply in self.stop_notifications.drain(..) {
                 reply.exit(Ok(()));
             }
-            return Ok(Async::NotReady);
+            return Ok(Async::Ready(()));
         }
         while let Async::Ready(Some(command)) = self.command_rx.poll().expect("Never fails") {
             self.handle_command(command);


### PR DESCRIPTION
## Types of changes
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes

### Purpose

To fix the incorrect return value of DaemonRunner. Originally, the return value is `Async::Ready(())` (See https://github.com/frugalos/frugalos/commit/1e24e806e2f053bd00682c84c6e5e27448e7cf1c#diff-de7d1c5164a16c3b86e59069620d7ec7R245).

## Checklists

- [x] I have run `cargo fmt --all`.