### PR TITLE
Don't return at the end of functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,10 +31,10 @@ fn main() {
         format!(
             "
 /// This takes one of \"debug\" or \"release\", that we've used to build this frugalos.
-pub static BUILD_PROFILE: &'static str = \"{}\";\n\n
+pub static BUILD_PROFILE: &str = \"{}\";\n\n
 
 /// This means the rustc version that we've used to build this frugalos.
-pub static BUILD_VERSION: &'static str = \"{}\";
+pub static BUILD_VERSION: &str = \"{}\";
 ",
             profile, version
         )

--- a/frugalos_mds/src/machine.rs
+++ b/frugalos_mds/src/machine.rs
@@ -106,9 +106,9 @@ impl Machine {
         if let Some(owner_id) = owner_id {
             let owner_id: ObjectId = track!(String::from_utf8(owner_id).map_err(Error::from))?;
             self.id_to_data.remove(&owner_id);
-            return Ok(self.id_to_version.remove(&owner_id));
+            Ok(self.id_to_version.remove(&owner_id))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
     pub fn delete_by_prefix(&mut self, object_prefix: &ObjectPrefix) -> Result<Vec<ObjectVersion>> {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes
最新 (rustc 1.37.0) の cargo clippy --all で警告が出なくなるようにする
### Behavior
なし
### Purpose
警告除去
## Checklists

- [x] I have run `cargo fmt --all`.