### PR TITLE
Limit repairing by concurrency - server side

### DIFF
--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -139,6 +139,7 @@ where
                 let logger = self.logger.clone();
                 let logger0 = logger.clone();
                 let logger1 = logger.clone();
+                let service_handle = self.handle();
                 let local_id = node_id.local_id;
                 let spawner = self.spawner.clone();
                 let rpc_service = self.rpc_service.clone();
@@ -184,6 +185,7 @@ where
                             mds_service,
                             node_id,
                             device,
+                            service_handle,
                             client,
                             cluster,
                             segment_node_command_rx
@@ -352,6 +354,7 @@ impl SegmentNode {
 
         node_id: NodeId,
         device: DeviceHandle,
+        service_handle: ServiceHandle,
         client: StorageClient,
         cluster: ClusterMembers,
         segment_node_command_rx: mpsc::Receiver<SegmentNodeCommand>,
@@ -408,8 +411,14 @@ impl SegmentNode {
             .unwrap_or(100);
         info!(logger, "FullSync step: {}", full_sync_step);
 
-        let synchronizer =
-            Synchronizer::new(logger.clone(), node_id, device, client, full_sync_step);
+        let synchronizer = Synchronizer::new(
+            logger.clone(),
+            node_id,
+            device,
+            service_handle,
+            client,
+            full_sync_step,
+        );
 
         Ok(SegmentNode {
             logger,

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -117,7 +117,10 @@ where
         if let Some(repair_concurrency_limit) = repair_config.repair_concurrency_limit {
             // Even if more than repair_concurrency_limit threads are running, we don't do anything to them.
             // Just let them finish their jobs.
-            let mut lock = self.repair_concurrency.lock().unwrap();
+            let mut lock = self
+                .repair_concurrency
+                .lock()
+                .unwrap_or_else(|e| panic!("Lock failed with error: {:?}", e));
             lock.set_limit(repair_concurrency_limit.0);
         }
     }

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -17,6 +17,7 @@ use client::storage::{GetFragment, MaybeFragment, StorageClient};
 use config;
 use full_sync::FullSync;
 use libfrugalos::repair::RepairIdleness;
+use service::ServiceHandle;
 use util::Phase3;
 use Error;
 
@@ -31,6 +32,8 @@ pub struct Synchronizer {
     node_id: NodeId,
     device: DeviceHandle,
     client: StorageClient,
+    #[allow(dead_code)]
+    service_handle: ServiceHandle,
     task: Task,
     // TODO: define specific types for two kinds of items and specialize the procedure for each todo queue
     todo_delete: BinaryHeap<Reverse<TodoItem>>, // To-do queue for delete. Can hold `TodoItem::DeleteContent`s only.
@@ -59,6 +62,7 @@ impl Synchronizer {
         logger: Logger,
         node_id: NodeId,
         device: DeviceHandle,
+        service_handle: ServiceHandle,
         client: StorageClient,
         full_sync_step: u64,
     ) -> Self {
@@ -71,6 +75,7 @@ impl Synchronizer {
             logger,
             node_id,
             device,
+            service_handle,
             client,
             task: Task::Idle,
             todo_delete: BinaryHeap::new(),


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes
復元リペア機能が、同時実行数の制限機能を持つようになる。

### Behavior
- SetRepairConfig RPC の repair_concurrency_limit パラメタが参照される。
- repair_concurrency_limit の値に基づいて、復元リペア機能の同時実行数が制限される。

### Purpose
復元リペア機能の負荷を制限した状態で使うための変更である。
この変更だけでは実行することはできず、RPC を叩くクライアントも作る必要がある。
クライアント側の変更は https://github.com/frugalos/frugalos/pull/198 で行う。

## Checklists

- [x] I have run `cargo fmt --all`.