### PR TITLE
Limit repairing by concurrency - client side

### DIFF
--- a/it/testsuites/repair.sh
+++ b/it/testsuites/repair.sh
@@ -66,7 +66,7 @@ for i in `seq 1 40`
 do
   # Constantly send repair requests, because frugalos shortly after booting can fail to serve these requests.
   docker exec clusters_frugalos01_1 \
-    frugalos set-repair-config --rpc-addr 172.18.0.22:8080 --repair-idleness-threshold 0.5 >/dev/null # sends rpc
+    frugalos set-repair-config --rpc-addr 172.18.0.22:8080 --repair-idleness-threshold 0.5 --repair-concurrency-limit 1 >/dev/null # sends rpc
   SUCC=`curl frugalos02/metrics 2>/dev/null | grep repairs_success_total | awk 'BEGIN { a = 0; } { a+= $2; } END { print a; }'`
   ENQ=`curl frugalos02/metrics 2>/dev/null | grep enqueued_item | grep repair | awk 'BEGIN { a = 0; } { a+= $2; } END { print a; }'`
   DEQ=`curl frugalos02/metrics 2>/dev/null | grep dequeued_item | grep repair | awk 'BEGIN { a = 0; } { a+= $2; } END { print a; }'`

--- a/src/command/set_repair_config.rs
+++ b/src/command/set_repair_config.rs
@@ -17,6 +17,8 @@ static REPAIR_IDLENESS_THRESHOLD: &str = "REPAIR_IDLENESS_THRESHOLD";
 static REPAIR_IDLENESS_THRESHOLD_LONG_ARG: &str = "repair-idleness-threshold";
 static DISABLE_REPAIR_IDLENESS: &str = "DISABLE_REPAIR_IDLENESS";
 static DISABLE_REPAIR_IDLENESS_LONG_ARG: &str = "disable-repair-idleness";
+static REPAIR_CONCURRENCY_LIMIT: &str = "REPAIR_CONCURRENCY_LIMIT";
+static REPAIR_CONCURRENCY_LIMIT_LONG_ARG: &str = "repair-concurrency-limit";
 
 impl FrugalosSubcommand for SetRepairConfigCommand {
     fn get_subcommand<'a, 'b: 'a>(&self) -> App<'a, 'b> {
@@ -33,8 +35,8 @@ impl FrugalosSubcommand for SetRepairConfigCommand {
                     .takes_value(false),
             )
             .arg(
-                Arg::with_name("REPAIR_CONCURRENCY_LIMIT")
-                    .long("repair-concurrency-limit")
+                Arg::with_name(REPAIR_CONCURRENCY_LIMIT)
+                    .long(REPAIR_CONCURRENCY_LIMIT_LONG_ARG)
                     .takes_value(true),
             )
     }
@@ -78,7 +80,7 @@ impl SetRepairConfigCommand {
                 RepairIdleness::Threshold(Duration::from_millis((duration_secs * 1000.0) as u64))
             })
         }
-        let repair_concurrency_limit = matches.value_of("REPAIR_CONCURRENCY_LIMIT").map(|str| {
+        let repair_concurrency_limit = matches.value_of(REPAIR_CONCURRENCY_LIMIT).map(|str| {
             let limit: u64 = track_try_unwrap!(str.parse().map_err(|_| Error::from(
                 ErrorKind::InvalidInput.cause("repair-concurrency-limit must be a u64")
             )));
@@ -96,7 +98,7 @@ impl SetRepairConfigCommand {
 #[cfg(test)]
 mod tests {
     use clap::App;
-    use libfrugalos::repair::{RepairConfig, RepairIdleness};
+    use libfrugalos::repair::{RepairConcurrencyLimit, RepairConfig, RepairIdleness};
     use std::time::Duration;
 
     use super::SetRepairConfigCommand;
@@ -112,14 +114,15 @@ mod tests {
                 "set-repair-config",
                 "--repair-idleness-threshold",
                 "4.0",
+                "--repair-concurrency-limit",
+                "100",
             ]);
         if let Some(matches) = set_repair_config_command.check_matches(&matches) {
             let repair_config = SetRepairConfigCommand::get_repair_config_from_matches(&matches);
             // TODO: we want to check repair_config directly, but it's not possible because RepairConfig doesn't implement Eq.
             // To circumvent this, we perform pattern matching.
-            eprintln!("{:?}", repair_config);
             if let RepairConfig {
-                repair_concurrency_limit: None,
+                repair_concurrency_limit: Some(RepairConcurrencyLimit(100)),
                 repair_idleness_threshold: Some(RepairIdleness::Threshold(duration)),
                 segment_gc_concurrency_limit: None,
             } = repair_config


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes
復元リペア機能の同時実行数の制限機能が実行できるようになる。

### Behavior
SetRepairConfig RPC に repair_concurrency_limit パラメタが設定できるようになる

### Purpose
https://github.com/frugalos/frugalos/pull/195 と合わせて、復元リペア機能の同時実行数が制限できるようになる。
## Checklists

- [x] I have run `cargo fmt --all`.