### PR TITLE
Drop rustc 1.31.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: rust
 
 rust:
   - stable
-  - 1.31.1
   - beta
   - nightly
 


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes
`rustc 1.31.1` を CI から外す。
## Checklists

- [x] I have run `cargo fmt --all`.