### PR TITLE
Changes the default value of `--stop-waiting-time-millis`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ fn default_sampling_rate() -> f64 {
 }
 
 fn default_stop_waiting_time() -> Duration {
-    Duration::from_millis(10)
+    Duration::from_millis(5000)
 }
 
 fn default_http_server_bind_addr() -> SocketAddr {


### PR DESCRIPTION
## Types of changes

Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of changes

### Behavior

最大停止待ち時間が 10 ms から 5000 ms に変わる。ただし、リクエストが来ていない場合は即座に終了し待ち時間はない。

### Purpose

現在のデフォルト値は不適切で `frugalos stop` 実行時にエラー終了しやすいため、停止するために余裕のある時間に変更する。

## Checklists

- [x] I have run `cargo fmt --all`.