### PR TITLE
Fixes warnings by deprecated features

### DIFF
--- a/frugalos_mds/src/error.rs
+++ b/frugalos_mds/src/error.rs
@@ -31,9 +31,8 @@ pub enum ErrorKind {
 impl TrackableErrorKind for ErrorKind {}
 
 /// クレート固有の`Error`型.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TrackableError)]
 pub struct Error(TrackableError<ErrorKind>);
-derive_traits_for_trackable_error_newtype!(Error, ErrorKind);
 impl From<libfrugalos::Error> for Error {
     fn from(f: libfrugalos::Error) -> Self {
         let kind = match *f.kind() {


### PR DESCRIPTION
## Types of changes

Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Purpose

rust 1.38 でコンパイル時に出る warnings を修正すること。以下の deprecated になっている warning を修正する。

```
warning: use of deprecated item 'derive_traits_for_trackable_error_newtype': please use `#[derive(TrackableError)]` instead
  --> frugalos_mds/src/error.rs:36:1
   |
36 | derive_traits_for_trackable_error_newtype!(Error, ErrorKind);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.