### PR TITLE
Update rust to 1.38.

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,5 +1,5 @@
 # STAGE-1: Build frugalos binary
-FROM rust:1.33.0-slim
+FROM rust:1.38.0-slim
 
 ARG FRUGALOS_VERSION
 


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes
DockerHub 用の Dockerfile のベースイメージを 1.33-slim から 1.38-slim に更新する。

### Behavior

### Purpose
frugalos が要求する rust のバージョンに満たないため

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.