### PR TITLE
Feature/put many objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod codec;
 mod config_server;
 mod error;
 mod http;
+mod many_objects;
 mod recovery;
 mod rpc_server;
 mod server;

--- a/src/many_objects.rs
+++ b/src/many_objects.rs
@@ -5,6 +5,7 @@ use client::FrugalosClient;
 use slog::Logger;
 use std::cmp::min;
 
+#[allow(clippy::too_many_arguments)]
 pub fn put_many_objects<E>(
     client: FrugalosClient,
     logger: Logger,
@@ -42,18 +43,15 @@ pub fn put_many_objects<E>(
                     .request(bucket_id.clone())
                     .put(object_id.clone(), content.clone())
                     .then(move |result| {
-                        match track!(result.clone()) {
-                            Err(e) => {
-                                warn!(
-                                    logger,
-                                    "Cannot put object (bucket={:?}, object={:?}): {}",
-                                    bucket_id,
-                                    object_id,
-                                    e,
-                                );
-                            }
-                            _ => (),
-                        };
+                        if let Err(e) = track!(result.clone()) {
+                            warn!(
+                                logger,
+                                "Cannot put object (bucket={:?}, object={:?}): {}",
+                                bucket_id,
+                                object_id,
+                                e,
+                            );
+                        }
                         ok(())
                     });
                 futures.push(future);

--- a/src/many_objects.rs
+++ b/src/many_objects.rs
@@ -9,6 +9,7 @@ pub fn put_many_objects<E>(
     logger: Logger,
     bucket_id: String,
     object_id_prefix: String,
+    object_start_index: usize,
     object_count: usize,
     content: Vec<u8>,
 ) -> impl Future<Item = (), Error = E> {
@@ -21,14 +22,15 @@ pub fn put_many_objects<E>(
             if index % 1000 == 0 {
                 info!(
                     logger,
-                    "Put done: {} / {} (bucket_id = {}, prefix = {})",
+                    "Put done: {} / {} (bucket_id = {}, prefix = {}, index = {})",
                     index,
                     object_count,
                     bucket_id,
                     object_id_prefix,
+                    object_start_index + index,
                 )
             }
-            let object_id = format!("{}{}", object_id_prefix, index);
+            let object_id = format!("{}{}", object_id_prefix, object_start_index + index);
             let future = client
                 .request(bucket_id.clone())
                 .put(object_id.clone(), content.clone())

--- a/src/many_objects.rs
+++ b/src/many_objects.rs
@@ -1,0 +1,60 @@
+use futures::future::{ok, Either, Loop};
+use futures::Future;
+
+use client::FrugalosClient;
+use slog::Logger;
+
+pub fn put_many_objects<E>(
+    client: FrugalosClient,
+    logger: Logger,
+    bucket_id: String,
+    object_id_prefix: String,
+    object_count: usize,
+    content: Vec<u8>,
+) -> impl Future<Item = (), Error = E> {
+    futures::future::loop_fn(
+        (0, logger, client, bucket_id, object_id_prefix, content),
+        move |(index, logger, client, bucket_id, object_id_prefix, content)| {
+            if index >= object_count {
+                return Either::A(ok(Loop::Break(())));
+            }
+            if index % 1000 == 0 {
+                info!(
+                    logger,
+                    "Put done: {} / {} (bucket_id = {}, prefix = {})",
+                    index,
+                    object_count,
+                    bucket_id,
+                    object_id_prefix,
+                )
+            }
+            let object_id = format!("{}{}", object_id_prefix, index);
+            let future = client
+                .request(bucket_id.clone())
+                .put(object_id.clone(), content.clone())
+                .then(move |result| {
+                    match track!(result.clone()) {
+                        Err(e) => {
+                            warn!(
+                                logger,
+                                "Cannot put object (bucket={:?}, object={:?}): {}",
+                                bucket_id,
+                                object_id,
+                                e,
+                            );
+                        }
+                        _ => (),
+                    };
+                    ok(Loop::Continue((
+                        index + 1,
+                        logger,
+                        client,
+                        bucket_id,
+                        object_id_prefix,
+                        content,
+                    )))
+                });
+            Either::B(future)
+        },
+    )
+}

--- a/src/many_objects.rs
+++ b/src/many_objects.rs
@@ -1,13 +1,16 @@
 use futures::future::{ok, Either, Loop};
 use futures::Future;
-
-use client::FrugalosClient;
+use rustracing::tag::Tag;
+use rustracing_jaeger::Span;
 use slog::Logger;
 use std::cmp::min;
+
+use client::FrugalosClient;
 
 #[allow(clippy::too_many_arguments)]
 pub fn put_many_objects<E>(
     client: FrugalosClient,
+    parent: Span,
     logger: Logger,
     bucket_id: String,
     object_id_prefix: String,
@@ -17,8 +20,16 @@ pub fn put_many_objects<E>(
     content: Vec<u8>,
 ) -> impl Future<Item = (), Error = E> {
     futures::future::loop_fn(
-        (0, logger, client, bucket_id, object_id_prefix, content),
-        move |(index, logger, client, bucket_id, object_id_prefix, content)| {
+        (
+            0,
+            parent,
+            logger,
+            client,
+            bucket_id,
+            object_id_prefix,
+            content,
+        ),
+        move |(index, parent, logger, client, bucket_id, object_id_prefix, content)| {
             if index >= object_count {
                 return Either::A(ok(Loop::Break(())));
             }
@@ -36,11 +47,17 @@ pub fn put_many_objects<E>(
             let mut futures = vec![];
             let this_time = min(object_count - index, concurrency);
             for i in 0..this_time {
+                let span = parent.child("put_many_objects.put", |span| {
+                    span.tag(Tag::new("index", (object_start_index + index + i) as i64))
+                        .start()
+                });
+
                 let object_id = format!("{}{}", object_id_prefix, object_start_index + index + i);
                 let logger = logger.clone();
                 let bucket_id = bucket_id.clone();
                 let future = client
                     .request(bucket_id.clone())
+                    .span(&span)
                     .put(object_id.clone(), content.clone())
                     .then(move |result| {
                         if let Err(e) = track!(result.clone()) {
@@ -59,6 +76,7 @@ pub fn put_many_objects<E>(
             let future = futures::future::join_all(futures).map(move |_| {
                 Loop::Continue((
                     index + this_time,
+                    parent,
                     logger,
                     client,
                     bucket_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -634,21 +634,12 @@ impl HandleRequest for PutManyObject {
         let n: Option<Option<usize>> = req.header().parse_field("content-length").ok();
         if let Some(Some(n)) = n {
             if n > MAX_PUT_OBJECT_SIZE {
-                let count = self.0.large_object_count.fetch_add(1, Ordering::SeqCst);
                 warn!(
                     self.0.logger,
                     "Too large body size ({} bytes): {}",
                     n,
                     req.url()
                 );
-                if count != 0 {
-                    // 最初だけはオブジェクトをダンプしたいので即座にエラーにはしない
-                    return Some(make_object_response(
-                        Status::BadRequest,
-                        None,
-                        Err(track!(ErrorKind::InvalidInput.cause("Too large body size")).into()),
-                    ));
-                }
             }
         }
         None

--- a/src/server.rs
+++ b/src/server.rs
@@ -673,16 +673,18 @@ impl HandleRequest for PutManyObject {
         let mut span = self
             .0
             .tracer
-            .span(|t| t.span("put_object").child_of(&client_span).start());
+            .span(|t| t.span("put_many_objects").child_of(&client_span).start());
         span.set_tag(|| StdTag::http_method("PUT"));
         span.set_tag(|| Tag::new("bucket.id", bucket_id.clone()));
         span.set_tag(|| Tag::new("object.id_prefix", object_id_prefix.clone()));
         span.set_tag(|| Tag::new("object.size", content.len().to_string()));
-        span.set_tag(|| Tag::new("object.count", format!("{}", object_count)));
+        span.set_tag(|| Tag::new("object.start", object_start_index as i64));
+        span.set_tag(|| Tag::new("object.count", object_count as i64));
 
         // TODO: deadline and expect
         let future = put_many_objects(
             self.0.client.clone(),
+            span,
             self.0.logger.clone(),
             bucket_id,
             object_id_prefix,

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,9 +28,7 @@ use url::Url;
 
 use client::FrugalosClient;
 use codec::{AsyncEncoder, ObjectResultEncoder};
-use http::{
-    make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader,
-};
+use http::{make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader};
 use many_objects::put_many_objects;
 use {Error, ErrorKind, FrugalosConfig, Result};
 
@@ -693,8 +691,9 @@ impl HandleRequest for PutManyObject {
             concurrency,
             content,
         );
-        let response =
-            make_object_response(Status::Created, Some(ObjectVersion(0)), Ok(Vec::new()));
+        // Errors are suppressed. Always return 201 Created.
+        let response = Res::new(Status::Created, HttpResult::Ok(Vec::new()));
+
         let future = future.map(|_| response);
         Box::new(future)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -660,6 +660,7 @@ impl HandleRequest for PutManyObject {
         let object_start_index =
             try_badarg_option!(try_badarg!(get_usize_option(req.url(), "start")));
         let object_count = try_badarg_option!(try_badarg!(get_usize_option(req.url(), "count")));
+        let concurrency = try_badarg!(get_usize_option(req.url(), "concurrency")).unwrap_or(10);
         let (req, content) = req.take_body();
         if content.len() > MAX_PUT_OBJECT_SIZE {
             warn!(
@@ -696,6 +697,7 @@ impl HandleRequest for PutManyObject {
             object_id_prefix,
             object_start_index,
             object_count,
+            concurrency,
             content,
         );
         let response =

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,7 +28,9 @@ use url::Url;
 
 use client::FrugalosClient;
 use codec::{AsyncEncoder, ObjectResultEncoder};
-use http::{make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader};
+use http::{
+    make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader,
+};
 use many_objects::put_many_objects;
 use {Error, ErrorKind, FrugalosConfig, Result};
 


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
例えば以下のようにすると、`random-1mib.dat` というファイルのデータが `many-1mib0` から `many-1mib19999` まで PUT される。PUT が完了するまでレスポンスは返ってこない。
```
$ time curl -XPUT --data-binary @random-1mib.dat 'frugalos:3000/v1/buckets/b0000/many_objects/many-1mib?start=0&count=20000'
```
また、`concurrency` パラメータで、何並列で PUT するかを指定できる。デフォルトは 10 である。

### Purpose
frugalos に多数のオブジェクトを PUT する機能があると、デバッグ時に便利であるため。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.