### PR TITLE
Drops some node labels from metrics.

### DIFF
--- a/frugalos_mds/src/node/node.rs
+++ b/frugalos_mds/src/node/node.rs
@@ -95,19 +95,16 @@ impl Metrics {
         let proposal_queue_len = track!(GaugeBuilder::new("proposal_queue_len")
             .namespace("frugalos")
             .subsystem("mds")
-            .label("node", &node)
             .default_registry()
             .finish())?;
         let snapshots_total = track!(CounterBuilder::new("snapshots_total")
             .namespace("frugalos")
             .subsystem("mds")
-            .label("node", &node)
             .default_registry()
             .finish())?;
         let snapshot_bytes_total = track!(CounterBuilder::new("snapshot_bytes_total")
             .namespace("frugalos")
             .subsystem("mds")
-            .label("node", &node)
             .default_registry()
             .finish())?;
         let snapshot_encoding_duration_seconds = track!(make_histogram(

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -41,7 +41,6 @@ impl Synchronizer {
         let metric_builder = MetricBuilder::new()
             .namespace("frugalos")
             .subsystem("synchronizer")
-            .label("node", &node_id.to_string())
             .clone();
         // Metrics related to queue length
         let enqueued_repair = metric_builder


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

大部分のメトリクスから node ラベルが削除される。ただし、 `frugalos_mds_objects` は必要なため例外的に残す。

### Purpose

prometheus のストレージを使いすぎるため node ラベルを削除する。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.