### PR TITLE
repair_prep が複数オブジェクトを返すようにする

### DIFF
--- a/frugalos_segment/src/queue_executor/general_queue_executor.rs
+++ b/frugalos_segment/src/queue_executor/general_queue_executor.rs
@@ -9,6 +9,7 @@ use slog::Logger;
 use std::cmp::{self, min, Reverse};
 use std::collections::{BTreeSet, BinaryHeap, VecDeque};
 use std::convert::Infallible;
+use std::env;
 use std::time::{Duration, SystemTime};
 
 use delete::DeleteContent;
@@ -17,7 +18,7 @@ use Error;
 
 const MAX_TIMEOUT_SECONDS: u64 = 60;
 const DELETE_CONCURRENCY: usize = 16;
-const REPAIR_PREP_CONCURRENCY: usize = 32;
+const REPAIR_PREP_CONCURRENCY: usize = 100;
 
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
 enum TodoItem {
@@ -94,6 +95,7 @@ pub(crate) struct GeneralQueueExecutor {
     delete_queue: DeleteQueue,
     task: Task,
     repair_candidates: BTreeSet<ObjectVersion>,
+    repair_prep_concurrency: usize,
 }
 
 impl GeneralQueueExecutor {
@@ -106,6 +108,12 @@ impl GeneralQueueExecutor {
         dequeued_repair_prep: &Counter,
         dequeued_delete: &Counter,
     ) -> Self {
+        // TODO: 正式に conf ファイルで指定できるようにする
+        let repair_prep_concurrency = env::var("FRUGALOS_REPAIR_PREP_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(REPAIR_PREP_CONCURRENCY);
+
         Self {
             logger: logger.clone(),
             node_id,
@@ -114,6 +122,7 @@ impl GeneralQueueExecutor {
             delete_queue: DeleteQueue::new(enqueued_delete, dequeued_delete),
             task: Task::Idle,
             repair_candidates: BTreeSet::new(),
+            repair_prep_concurrency,
         }
     }
     pub(crate) fn push(&mut self, event: &Event) {
@@ -200,7 +209,7 @@ impl Stream for GeneralQueueExecutor {
                 popped_versions.push(version);
             }
             // REPAIR_PREP_CONCURRENCY 個ごとに repair キューに送信する
-            if popped_versions.len() >= REPAIR_PREP_CONCURRENCY {
+            if popped_versions.len() >= self.repair_prep_concurrency {
                 return Ok(Async::Ready(Some(popped_versions)));
             }
             if let Some(item) = self.pop() {

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -164,11 +164,13 @@ impl Future for Synchronizer {
             self.segment_gc_metrics.reset();
         }
 
-        if let Async::Ready(Some(version)) = self.general_queue.poll().unwrap_or_else(|e| {
+        if let Async::Ready(Some(versions)) = self.general_queue.poll().unwrap_or_else(|e| {
             warn!(self.logger, "Task failure in general_queue: {}", e);
             Async::Ready(None)
         }) {
-            self.repair_queue.push(version);
+            for version in versions {
+                self.repair_queue.push(version);
+            }
         }
 
         // Never stops, never fails.


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
repair_prep はもともとは1 個の ObjectVersion を返す Stream だったが、この変更により複数個の ObjectVersion を返すようになる。
### Purpose
もともとの実装だと、リペアすべきオブジェクトが見つかるたびに毎回 GeneralQueue の実行が中断され、結果としてキューの処理に時間がかかるという問題があった。この変更により、ややハック気味だが複数個まとめてオブジェクトを処理できるようになる。
## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.