### PR TITLE
Changes the timeout duration of a MDS request to reduce latency

### DIFF
--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -343,16 +343,13 @@ impl MdsClient {
         Request::new(self.clone(), parent, request)
     }
 
-    fn timeout(&self, kind: RequestKind, max_retry: usize) -> RequestTimeout {
+    fn timeout(&self, kind: RequestKind) -> RequestTimeout {
         match self.request_policy(&kind) {
             // for backward compatibility
             MdsRequestPolicy::Conservative => RequestTimeout::Never,
-            MdsRequestPolicy::Speculative { timeout, .. } => {
-                let factor = 2u32.pow((self.member_size().saturating_sub(max_retry)) as u32);
-                RequestTimeout::Speculative {
-                    timer: timer::timeout(*timeout * factor),
-                }
-            }
+            MdsRequestPolicy::Speculative { timeout, .. } => RequestTimeout::Speculative {
+                timer: timer::timeout(*timeout),
+            },
         }
     }
     fn request_policy(&self, kind: &RequestKind) -> &MdsRequestPolicy {
@@ -563,7 +560,7 @@ where
 {
     pub fn new(client: MdsClient, parent: SpanHandle, request: T) -> Self {
         let max_retry = client.member_size();
-        let timeout = client.timeout(request.kind(), max_retry);
+        let timeout = client.timeout(request.kind());
         Request {
             client,
             max_retry,
@@ -579,7 +576,7 @@ where
         self.max_retry -= 1;
         let (peers, future) = track!(self.request.request_once(&self.client, &self.parent))?;
         self.peers = peers;
-        self.timeout = self.client.timeout(self.request.kind(), self.max_retry);
+        self.timeout = self.client.timeout(self.request.kind());
         self.future = Some(future);
         Ok(())
     }


### PR DESCRIPTION
#172  Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

MDS へのリクエストで固定時間のタイムアウトを常に使うようになる。

### Purpose

クラスタ数が大きい場合に exponential back-off をするとタイムアウト待ち時間が大きくなりすぎ、リクエストにタイムアウトを設定することでレイテンシを改善するという目的が達成できなくなるのを避けること。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.