### PR TITLE
Tracks dangling fragments even if PutAll doesn't recognize errors

### DIFF
--- a/frugalos_segment/src/metrics.rs
+++ b/frugalos_segment/src/metrics.rs
@@ -8,6 +8,7 @@ use Result;
 pub struct PutAllMetrics {
     pub(crate) failures_total: Counter,
     pub(crate) lost_fragments_total: Counter,
+    pub(crate) dangling_fragments_total: Counter,
 }
 
 impl PutAllMetrics {
@@ -22,13 +23,22 @@ impl PutAllMetrics {
         let lost_fragments_total = track!(CounterBuilder::new("put_all_lost_fragments_total")
             .namespace("frugalos")
             .subsystem("segment")
-            .help("Number of lost fragments")
+            .help("Number of surely lost fragments")
             .label("client", client_name)
             .default_registry()
             .finish())?;
+        let dangling_fragments_total =
+            track!(CounterBuilder::new("put_all_dangling_fragments_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("Number of dangling fragments")
+                .label("client", client_name)
+                .default_registry()
+                .finish())?;
         Ok(PutAllMetrics {
             failures_total,
             lost_fragments_total,
+            dangling_fragments_total,
         })
     }
 }


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

フラグメントの保存で結果が不明になったフラグメントの個数をメトリクス(`frugalos_segment_put_all_dangling_fragments_total`)に出す。

### Purpose

`PutAll` した後に完了を待っていないフラグメントがあり、完了した/していないを知ること。

ただし、このメトリクス追加では保存されなかったフラグメントがあるかは正確には分からない。別途、すべてのフラグメント保存用の future の完了まで確認する修正が必要。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.