### PR TITLE
Remove StoppableHttpServer

### DIFF
--- a/docker/frugalos/frugalos.yml
+++ b/docker/frugalos/frugalos.yml
@@ -2,7 +2,6 @@
 # 設定項目については https://github.com/frugalos/frugalos/wiki/Configuration を参照。
 frugalos:
   daemon:
-    stop_waiting_time_millis: 3000
   rpc_client:
     tcp_connect_timeout_millis: 5000
     tcp_write_timeout_millis: 5000

--- a/docker/frugalos/frugalos.yml
+++ b/docker/frugalos/frugalos.yml
@@ -1,7 +1,6 @@
 ---
 # 設定項目については https://github.com/frugalos/frugalos/wiki/Configuration を参照。
 frugalos:
-  daemon:
   rpc_client:
     tcp_connect_timeout_millis: 5000
     tcp_write_timeout_millis: 5000

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,7 +3,6 @@
 use fibers::executor::ThreadPoolExecutorHandle;
 use fibers::sync::mpsc;
 use fibers::sync::oneshot;
-use fibers::time::timer;
 use fibers::{Executor, Spawn, ThreadPoolExecutor};
 use fibers_http_server::metrics::{MetricsHandler, WithMetrics};
 use fibers_http_server::{Server as HttpServer, ServerBuilder as HttpServerBuilder};
@@ -23,7 +22,6 @@ use slog::{self, Drain, Logger};
 use std::mem;
 use std::net::SocketAddr;
 use std::process::Command;
-use std::time::Duration;
 use trackable::error::ErrorKindExt;
 
 use config_server::ConfigServer;
@@ -32,11 +30,10 @@ use recovery::prepare_recovery;
 use rpc_server::RpcServer;
 use server::{spawn_report_spans_thread, Server};
 use service;
-use {Error, ErrorKind, FrugalosConfig, FrugalosDaemonConfig, Result};
+use {Error, ErrorKind, FrugalosConfig, Result};
 
 /// Frugalosの各種機能を提供するためのデーモン。
 pub struct FrugalosDaemon {
-    logger: Logger,
     service: service::Service<ThreadPoolExecutorHandle>,
     http_server_builder: HttpServerBuilder,
     rpc_server_builder: RpcServerBuilder,
@@ -126,7 +123,6 @@ impl FrugalosDaemon {
         track!(config_server.register(&mut http_server_builder))?;
 
         Ok(FrugalosDaemon {
-            logger: logger.clone(),
             service,
             http_server_builder,
             rpc_server_builder,
@@ -166,21 +162,16 @@ impl FrugalosDaemon {
     /// 各種サーバを起動して、処理を実行する。
     ///
     /// この呼び出しはブロッキングするので注意。
-    pub fn run(mut self, config: FrugalosDaemonConfig) -> Result<()> {
+    pub fn run(mut self) -> Result<()> {
         track!(self.register_prometheus_metrics())?;
 
         let runner = DaemonRunner {
-            logger: self.logger.clone(),
-            config,
             service: self.service,
             rpc_server: self.rpc_server_builder.finish(self.executor.handle()),
-            http_server: StoppableHttpServer::new(
-                self.http_server_builder.finish(self.executor.handle()),
-            ),
+            http_server: self.http_server_builder.finish(self.executor.handle()),
             rpc_service: self.rpc_service,
             command_rx: self.command_rx,
             stop_notifications: Vec::new(),
-            do_stop: false,
         };
 
         let monitor = self.executor.handle().spawn_monitor(runner);
@@ -190,25 +181,17 @@ impl FrugalosDaemon {
 }
 
 struct DaemonRunner {
-    logger: Logger,
-    config: FrugalosDaemonConfig,
     service: service::Service<ThreadPoolExecutorHandle>,
-    http_server: StoppableHttpServer,
+    http_server: HttpServer,
     rpc_server: fibers_rpc::server::Server<ThreadPoolExecutorHandle>,
     rpc_service: fibers_rpc::client::ClientService,
     command_rx: mpsc::Receiver<DaemonCommand>,
     stop_notifications: Vec<oneshot::Monitored<(), Error>>,
-    do_stop: bool,
 }
 impl DaemonRunner {
     fn handle_command(&mut self, command: DaemonCommand) {
         match command {
             DaemonCommand::StopDaemon { reply } => {
-                info!(
-                    self.logger,
-                    "Begins stopping and waits for a while({:?})", self.config.stop_waiting_time
-                );
-                self.http_server.stop(self.config.stop_waiting_time);
                 self.service.stop();
                 self.stop_notifications.push(reply);
             }
@@ -223,14 +206,11 @@ impl Future for DaemonRunner {
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let do_stop = track!(self.http_server.poll())?.is_ready() && self.do_stop;
-        if do_stop {
-            return Ok(Async::Ready(()));
-        }
+        track!(self.http_server.poll())?;
         track!(self.rpc_server.poll())?;
         track!(self.rpc_service.poll())?;
-        self.do_stop = self.do_stop || track!(self.service.poll())?.is_ready();
-        if self.do_stop {
+        let ready = track!(self.service.poll())?.is_ready();
+        if ready {
             for reply in self.stop_notifications.drain(..) {
                 reply.exit(Ok(()));
             }
@@ -285,36 +265,6 @@ impl Future for StopDaemon {
             .map_err(|e| e.unwrap_or_else(|| ErrorKind::Other
                 .cause("Monitoring channel disconnected")
                 .into())))
-    }
-}
-
-struct StoppableHttpServer {
-    inner: Option<HttpServer>,
-    stop_timer: Option<timer::Timeout>,
-}
-impl StoppableHttpServer {
-    fn new(server: HttpServer) -> Self {
-        Self {
-            inner: Some(server),
-            stop_timer: None,
-        }
-    }
-    fn stop(&mut self, waiting_time: Duration) {
-        self.inner = None;
-        self.stop_timer = Some(timer::timeout(waiting_time));
-    }
-}
-impl Future for StoppableHttpServer {
-    type Item = ();
-    type Error = fibers_http_server::Error;
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if let Some(inner) = self.inner.as_mut() {
-            inner.poll()
-        } else if self.stop_timer.poll().expect("Broken timer").is_ready() {
-            Ok(Async::Ready(()))
-        } else {
-            Ok(Async::NotReady)
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,14 +157,6 @@ pub struct FrugalosDaemonConfig {
     /// Jaegerのトレースのサンプリング確率。
     #[serde(default = "default_sampling_rate")]
     pub sampling_rate: f64,
-
-    /// frugalos 停止時に待つ時間。
-    #[serde(
-        rename = "stop_waiting_time_millis",
-        default = "default_stop_waiting_time",
-        with = "frugalos_core::serde_ext::duration_millis"
-    )]
-    pub stop_waiting_time: Duration,
 }
 
 impl Default for FrugalosDaemonConfig {
@@ -172,7 +164,6 @@ impl Default for FrugalosDaemonConfig {
         Self {
             executor_threads: default_executor_threads(),
             sampling_rate: default_sampling_rate(),
-            stop_waiting_time: default_stop_waiting_time(),
         }
     }
 }
@@ -239,10 +230,6 @@ fn default_sampling_rate() -> f64 {
     0.001
 }
 
-fn default_stop_waiting_time() -> Duration {
-    Duration::from_millis(5000)
-}
-
 fn default_http_server_bind_addr() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], 3000))
 }
@@ -285,7 +272,6 @@ frugalos:
   daemon:
     executor_threads: 3
     sampling_rate: 0.1
-    stop_waiting_time_millis: 300
   http_server:
     bind_addr: "127.0.0.1:2222"
   rpc_client:
@@ -331,7 +317,6 @@ frugalos:
         expected.loglevel = sloggers::types::Severity::Critical;
         expected.daemon.sampling_rate = 0.1;
         expected.daemon.executor_threads = 3;
-        expected.daemon.stop_waiting_time = Duration::from_millis(300);
         expected.http_server.bind_addr = SocketAddr::from(([127, 0, 0, 1], 2222));
         expected.rpc_client.tcp_connect_timeout = Duration::from_secs(8);
         expected.rpc_client.tcp_write_timeout = Duration::from_secs(10);

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,11 +89,6 @@ fn main() {
                         .takes_value(true),
                 )
                 .arg(
-                    Arg::with_name("STOP_WAITING_TIME_MILLIS")
-                        .long("stop-waiting-time-millis")
-                        .takes_value(true),
-                )
-                .arg(
                     Arg::with_name("RPC_CONNECT_TIMEOUT_MILLIS")
                         .long("rpc-connect-timeout-millis")
                         .takes_value(true),
@@ -406,12 +401,6 @@ fn set_daemon_config(
     }
     if let Some(v) = matches.value_of("SAMPLING_RATE") {
         config.sampling_rate = v.parse().map_err(|e| track!(Error::from(e)))?;
-    }
-    if let Some(v) = matches.value_of("STOP_WAITING_TIME_MILLIS") {
-        config.stop_waiting_time = v
-            .parse::<u64>()
-            .map(Duration::from_millis)
-            .map_err(|e| track!(Error::from(e)))?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() {
             &logger,
             config.clone()
         ));
-        track_try_unwrap!(daemon.run(config.daemon.clone()));
+        track_try_unwrap!(daemon.run());
         // NOTE: ログ出力(非同期)用に少し待機
         std::thread::sleep(std::time::Duration::from_millis(100));
         debug!(logger, "config: {:?}", config);


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

- StoppableHttpServer の削除
  - DaemonRunner が直接 `fibers_http_server::Server` を所有し DaemonRunner の drop 時に http_server の drop も実行されるようになる
- 上記に伴い stop_waiting_time パラメータの削除

### Purpose

- 元々 StoppableHttpServer が所有する timer が Async::Ready() を返した後も DaemonRunner が再び poll してしまう問題があり、その対応が必要だった
- stop_waiting_time 自体はもともと不整合問題の調査向けでもあったが、現在は問題が解消されたと見られるため

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.