### PR TITLE
Add some metrics to DispersedClient

### DIFF
--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -23,7 +23,8 @@ use {Error, ErrorKind, ObjectValue, Result};
 pub enum StorageClient {
     Metadata,
     Replicated(ReplicatedClient),
-    Dispersed(DispersedClient),
+    // `#[warn(clippy::large_enum_variant)]` への対応
+    Dispersed(Box<DispersedClient>),
 }
 impl StorageClient {
     pub fn new(
@@ -47,7 +48,7 @@ impl StorageClient {
             }
             Storage::Dispersed(c) => {
                 let metrics = track!(DispersedClientMetrics::new())?;
-                Ok(StorageClient::Dispersed(DispersedClient::new(
+                Ok(StorageClient::Dispersed(Box::new(DispersedClient::new(
                     logger,
                     metrics,
                     config.cluster,
@@ -55,7 +56,7 @@ impl StorageClient {
                     config.dispersed_client,
                     rpc_service,
                     ec,
-                )))
+                ))))
             }
         }
     }

--- a/frugalos_segment/src/metrics.rs
+++ b/frugalos_segment/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics for `frugalos_segment`.
 
-use prometrics::metrics::{Counter, CounterBuilder};
+use prometrics::metrics::{Counter, CounterBuilder, Histogram, HistogramBuilder};
 
 use Result;
 
@@ -34,14 +34,137 @@ impl PutAllMetrics {
 }
 
 #[derive(Debug, Clone)]
+pub struct CollectFragmentsMetrics {
+    pub(crate) corrupted_fragments_total: Counter,
+    pub(crate) get_fragment_failures_total: Counter,
+    pub(crate) get_fragment_timeout_total: Counter,
+    pub(crate) get_fragment_success_duration_seconds: Histogram,
+    pub(crate) missing_fragments_total: Counter,
+}
+impl CollectFragmentsMetrics {
+    fn new() -> Result<Self> {
+        let corrupted_fragments_total = track!(CounterBuilder::new(
+            "collect_fragments_corrupted_fragments_total"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Number of corrupted fragments")
+        .default_registry()
+        .finish())?;
+        let get_fragment_failures_total = track!(CounterBuilder::new(
+            "collect_fragments_get_fragment_failures_total"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Number of failures when getting a fragment")
+        .default_registry()
+        .finish())?;
+        let get_fragment_timeout_total = track!(CounterBuilder::new(
+            "collect_fragments_get_fragment_timeout_total"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Number of timeout when getting a fragment")
+        .default_registry()
+        .finish())?;
+        let get_fragment_success_duration_seconds = track!(HistogramBuilder::new(
+            "collect_fragments_get_fragment_success_duration_seconds"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Get a fragment duration excluding failed fragments")
+        .bucket(0.001)
+        .bucket(0.005)
+        .bucket(0.01)
+        .bucket(0.05)
+        .bucket(0.1)
+        .bucket(0.5)
+        .bucket(1.0)
+        .bucket(2.0)
+        .bucket(4.0)
+        .bucket(8.0)
+        .default_registry()
+        .finish())?;
+        let missing_fragments_total = track!(CounterBuilder::new(
+            "collect_fragments_missing_fragments_total"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Number of missing fragments")
+        .default_registry()
+        .finish())?;
+        Ok(CollectFragmentsMetrics {
+            corrupted_fragments_total,
+            get_fragment_failures_total,
+            get_fragment_timeout_total,
+            get_fragment_success_duration_seconds,
+            missing_fragments_total,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DispersedClientMetrics {
     pub(crate) put_all: PutAllMetrics,
+    pub(crate) collect_fragments: CollectFragmentsMetrics,
+    pub(crate) dispersed_get_duration_seconds: Histogram,
+    pub(crate) dispersed_get_failures_total: Counter,
+    pub(crate) dispersed_head_failures_total: Counter,
+    pub(crate) dispersed_put_failures_total: Counter,
 }
 
 impl DispersedClientMetrics {
     pub fn new() -> Result<Self> {
         let put_all = track!(PutAllMetrics::new("dispersed_client"))?;
-        Ok(DispersedClientMetrics { put_all })
+        let collect_fragments = track!(CollectFragmentsMetrics::new())?;
+        let dispersed_get_duration_seconds =
+            track!(HistogramBuilder::new("dispersed_get_duration_seconds")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("DispersedGet duration")
+                .bucket(0.001)
+                .bucket(0.005)
+                .bucket(0.01)
+                .bucket(0.05)
+                .bucket(0.1)
+                .bucket(0.5)
+                .bucket(1.0)
+                .bucket(2.0)
+                .bucket(4.0)
+                .bucket(8.0)
+                .bucket(16.0)
+                .bucket(32.0)
+                .default_registry()
+                .finish())?;
+        let dispersed_get_failures_total =
+            track!(CounterBuilder::new("dispersed_get_failures_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("Number of dispersed get failures")
+                .default_registry()
+                .finish())?;
+        let dispersed_head_failures_total =
+            track!(CounterBuilder::new("dispersed_head_failures_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("Number of dispersed head failures")
+                .default_registry()
+                .finish())?;
+        let dispersed_put_failures_total =
+            track!(CounterBuilder::new("dispersed_put_failures_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("Number of dispersed put failures")
+                .default_registry()
+                .finish())?;
+        Ok(DispersedClientMetrics {
+            put_all,
+            collect_fragments,
+            dispersed_get_duration_seconds,
+            dispersed_get_failures_total,
+            dispersed_head_failures_total,
+            dispersed_put_failures_total,
+        })
     }
 }
 


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

TBD

### Purpose

fixes https://github.com/frugalos/frugalos/issues/152

`DispersedClient` で以下のメトリクスを取得する:

* 壊れたフラグメントの個数
* ストレージに存在しなかったフラグメントの個数
* フラグメント取得時にタイムアウトが発生した回数
* 1 つのフラグメントの取得にかかった時間
* すべてのフラグメントの取得にかかった時間(失敗時も含む) 
* `DispersedGet` の失敗回数
* `DispersedPut` の失敗回数
* `DispersedHead` の失敗回数

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.