### PR TITLE
`/v1/buckets/*/stats`/`/v1/buckets/*/segments/*/objects` supports con…

### DIFF
--- a/frugalos_mds/src/node/handle.rs
+++ b/frugalos_mds/src/node/handle.rs
@@ -64,9 +64,12 @@ impl NodeHandle {
             .map_err(|e| track!(Error::from(e)));
         Either::A(future)
     }
-    pub fn list_objects(&self) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
+    pub fn list_objects(
+        &self,
+        consistency: ReadConsistency,
+    ) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
         let (monitored, monitor) = oneshot::monitor();
-        let request = Request::List(monitored);
+        let request = Request::List(consistency, monitored);
         future_try!(self.request_tx.send(request));
         let future = monitor.map_err(|e| track!(Error::from(e)));
         Either::A(future)
@@ -81,9 +84,12 @@ impl NodeHandle {
         Either::A(future)
     }
 
-    pub fn object_count(&self) -> impl Future<Item = u64, Error = Error> {
+    pub fn object_count(
+        &self,
+        consistency: ReadConsistency,
+    ) -> impl Future<Item = u64, Error = Error> {
         let (monitored, monitor) = oneshot::monitor();
-        let request = Request::ObjectCount(monitored);
+        let request = Request::ObjectCount(consistency, monitored);
 
         future_try!(self.request_tx.send(request));
         let future = monitor.map_err(|e| track!(Error::from(e)));

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -181,9 +181,9 @@ impl ProposalMetrics {
 pub(crate) enum Request {
     StartElection,
     GetLeader(Instant, Reply<NodeId>),
-    List(Reply<Vec<ObjectSummary>>),
+    List(ReadConsistency, Reply<Vec<ObjectSummary>>),
     LatestVersion(Reply<Option<ObjectSummary>>),
-    ObjectCount(Reply<u64>),
+    ObjectCount(ReadConsistency, Reply<u64>),
     Get(
         ObjectId,
         Expect,
@@ -222,9 +222,9 @@ impl Request {
     pub fn failed(self, e: Error) {
         match self {
             Request::GetLeader(_, tx) => tx.exit(Err(track!(e))),
-            Request::List(tx) => tx.exit(Err(track!(e))),
+            Request::List(_, tx) => tx.exit(Err(track!(e))),
             Request::LatestVersion(tx) => tx.exit(Err(track!(e))),
-            Request::ObjectCount(tx) => tx.exit(Err(track!(e))),
+            Request::ObjectCount(_, tx) => tx.exit(Err(track!(e))),
             Request::Get(_, _, _, _, tx) => tx.exit(Err(track!(e))),
             Request::Head(_, _, _, tx) => tx.exit(Err(track!(e))),
             Request::Put(_, _, _, _, _, tx) => tx.exit(Err(track!(e))),

--- a/frugalos_mds/src/server.rs
+++ b/frugalos_mds/src/server.rs
@@ -113,10 +113,13 @@ impl HandleCall<rpc::GetLeaderRpc> for Server {
 }
 impl HandleCall<rpc::ListObjectsRpc> for Server {
     fn handle_call(&self, request: rpc::ListObjectsRequest) -> Reply<rpc::ListObjectsRpc> {
-        // TODO: supports consistency levels
         let node_id = rpc_try!(request.node_id.parse().map_err(Error::from));
         let node = rpc_try!(self.get_node(node_id));
-        Reply::future(node.list_objects().map_err(to_rpc_error).then(Ok))
+        Reply::future(
+            node.list_objects(request.consistency)
+                .map_err(to_rpc_error)
+                .then(Ok),
+        )
     }
 }
 
@@ -130,10 +133,13 @@ impl HandleCall<rpc::GetLatestVersionRpc> for Server {
 
 impl HandleCall<rpc::GetObjectCountRpc> for Server {
     fn handle_call(&self, request: rpc::ObjectCountRequest) -> Reply<rpc::GetObjectCountRpc> {
-        // TODO: supports consistency levels
         let node_id = rpc_try!(request.node_id.parse().map_err(Error::from));
         let node = rpc_try!(self.get_node(node_id));
-        Reply::future(node.object_count().map_err(to_rpc_error).then(Ok))
+        Reply::future(
+            node.object_count(request.consistency)
+                .map_err(to_rpc_error)
+                .then(Ok),
+        )
     }
 }
 

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -210,8 +210,12 @@ impl Client {
     }
 
     /// 保存済みのオブジェクト一覧を取得する。
-    pub fn list(&self) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
-        self.mds.list()
+    pub fn list(
+        &self,
+        consistency: ReadConsistency,
+        parent: SpanHandle,
+    ) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
+        self.mds.list(consistency, parent)
     }
 
     /// セグメント内の最新オブジェクトのバージョンを取得する。
@@ -220,8 +224,12 @@ impl Client {
     }
 
     /// セグメント内に保持されているオブジェクトの数を返す.
-    pub fn object_count(&self) -> impl Future<Item = u64, Error = Error> {
-        self.mds.object_count()
+    pub fn object_count(
+        &self,
+        consistency: ReadConsistency,
+        parent: SpanHandle,
+    ) -> impl Future<Item = u64, Error = Error> {
+        self.mds.object_count(consistency, parent)
     }
 }
 

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -138,13 +138,21 @@ pub struct MdsClientConfig {
     #[serde(default)]
     pub default_request_policy: MdsRequestPolicy,
 
-    /// Request policy for mds get requests.
+    /// Request policy for mds `Get` requests.
     #[serde(default)]
     pub get_request_policy: MdsRequestPolicy,
 
-    /// Request policy for mds head requests.
+    /// Request policy for mds `Head` requests.
     #[serde(default)]
     pub head_request_policy: MdsRequestPolicy,
+
+    /// Request policy for mds `List` requests.
+    #[serde(default)]
+    pub list_request_policy: MdsRequestPolicy,
+
+    /// Request policy for mds `ObjectCount` requests.
+    #[serde(default)]
+    pub object_count_request_policy: MdsRequestPolicy,
 }
 
 fn default_mds_client_request_timeout() -> Duration {
@@ -159,6 +167,8 @@ impl Default for MdsClientConfig {
             default_request_policy: Default::default(),
             get_request_policy: Default::default(),
             head_request_policy: Default::default(),
+            list_request_policy: Default::default(),
+            object_count_request_policy: Default::default(),
         }
     }
 }

--- a/it/testsuites/consistency.sh
+++ b/it/testsuites/consistency.sh
@@ -19,7 +19,9 @@ docker-compose -f it/clusters/${CLUSTER}.yml up -d
 mkdir -p ${WORK_DIR}
 sudo chmod 777 ${WORK_DIR}
 sleep 1
-curl -f http://frugalos01/v1/servers | tee $WORK_DIR/servers.json
+HOST=frugalos03
+HOST_IP=`getent ahosts $HOST | head -1 | awk '{print $1}'`
+curl -f http://$HOST_IP/v1/servers | tee $WORK_DIR/servers.json
 SERVERS=`jq 'map(.id) | .[]' /tmp/frugalos_it/servers.json | sed -e 's/"//g'`
 
 #
@@ -36,7 +38,8 @@ curl http://frugalos01/v1/buckets
 #
 # Puts objects
 #
-it/scripts/gen_put_requests.sh frugalos03 live_archive_chunk 1 1000 $WORK_DIR/req.json
+
+it/scripts/gen_put_requests.sh $HOST live_archive_chunk 1 1000 $WORK_DIR/req.json
 sleep 5
 hb run -i $WORK_DIR/req.json | hb summary
 sleep 5
@@ -46,16 +49,17 @@ sleep 30
 #
 # GET/HEAD
 #
-QUERY_PARAMS="?consistency=stale"           it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=quorum"          it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=1" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=2" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=consistent"      it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=stale"           it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=quorum"          it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=1" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=2" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=consistent"      it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+declare -a query_params=("?consistency=stale" "?consistency=quorum" "?consistency=subset&subset=1" "?consistency=subset&subset=2" "?consistency=consistent")
+for q in ${query_params[@]}
+do
+    # FIXME: http_requests.sh より汎用的に使える HTTP リクエスト実行ツールが必要
+    hb run -i <(jo -a $(jo method=GET url=http://$HOST_IP/v1/buckets/live_archive_chunk/segments/0/objects$q)) -o $WORK_DIR/res.json
+    [ `hb summary -i $WORK_DIR/res.json | jq ".status.\"200\""` -eq "1" ]
+    hb run -i <(jo -a $(jo method=GET url=http://$HOST_IP/v1/buckets/live_archive_chunk/stats$q)) -o $WORK_DIR/res.json
+    [ `hb summary -i $WORK_DIR/res.json | jq ".status.\"200\""` -eq "1" ]
+    QUERY_PARAMS="$q" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+    QUERY_PARAMS="$q" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+done
 
 #
 # ノードが1台停止中での GET/HEAD
@@ -63,16 +67,15 @@ QUERY_PARAMS="?consistency=consistent"      it/scripts/http_requests.sh HEAD 200
 docker-compose -f it/clusters/${CLUSTER}.yml stop frugalos02
 # ハートビート間隔より長い時間待つ必要がある
 sleep 10
-QUERY_PARAMS="?consistency=stale"           it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=quorum"          it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=1" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=2" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=consistent"      it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=stale"           it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=quorum"          it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=1" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=subset&subset=2" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
-QUERY_PARAMS="?consistency=consistent"      it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+for q in ${query_params[@]}
+do
+    hb run -i <(jo -a $(jo method=GET url=http://$HOST_IP/v1/buckets/live_archive_chunk/segments/0/objects$q)) -o $WORK_DIR/res.json
+    [ `hb summary -i $WORK_DIR/res.json | jq ".status.\"200\""` -eq "1" ]
+    hb run -i <(jo -a $(jo method=GET url=http://$HOST_IP/v1/buckets/live_archive_chunk/stats$q)) -o $WORK_DIR/res.json
+    [ `hb summary -i $WORK_DIR/res.json | jq ".status.\"200\""` -eq "1" ]
+    QUERY_PARAMS="$q" it/scripts/http_requests.sh GET 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+    QUERY_PARAMS="$q" it/scripts/http_requests.sh HEAD 200 $WORK_DIR/req.json $WORK_DIR/res.json 1000
+done
 
 #
 # Cleanups cluster

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -187,11 +187,10 @@ impl HandleCall<rpc::PutObjectRpc> for RpcServer {
 }
 impl HandleCall<rpc::ListObjectsRpc> for RpcServer {
     fn handle_call(&self, request: rpc::ListObjectsRequest) -> Reply<rpc::ListObjectsRpc> {
-        // TODO: supports consistency levels
         let future = self
             .client
             .request(request.bucket_id)
-            .list(request.segment as usize);
+            .list(request.segment as usize, request.consistency);
         Reply::future(future.map_err(into_rpc_error).then(Ok))
     }
 }


### PR DESCRIPTION
…sistency

## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

MDS に対するオブジェクト一覧取得とオブジェクト個数カウント処理で整合性の指定ができるようになる。

整合性を指定した場合の動作はすでに実装されている GET/HEAD と同様。

### Purpose

オブジェクト個数の取得時/リスト時に Raft の選挙が起きてもクライアントをブロックしないようにすること。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.