### PR TITLE
Add a new endpoint `HEAD /v1/buckets/*/objects/*/fragments`

### DIFF
--- a/frugalos_segment/src/client/dispersed_storage.rs
+++ b/frugalos_segment/src/client/dispersed_storage.rs
@@ -743,8 +743,12 @@ impl Future for DispersedCountFragments {
                     self.summary.lost_total += 1;
                     remainings
                 }
-                Ok(Async::Ready((lump_header, _, remainings))) => {
-                    self.summary.found_total += lump_header.map_or(0, |_| 1);
+                Ok(Async::Ready((Some(_), _, remainings))) => {
+                    self.summary.found_total += 1;
+                    remainings
+                }
+                Ok(Async::Ready((None, _, remainings))) => {
+                    self.summary.lost_total += 1;
                     remainings
                 }
             };

--- a/frugalos_segment/src/client/replicated_storage.rs
+++ b/frugalos_segment/src/client/replicated_storage.rs
@@ -5,7 +5,7 @@ use cannyls_rpc::DeviceId;
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_raft::NodeId;
 use futures::{Async, Future, Poll};
-use libfrugalos::entity::object::ObjectVersion;
+use libfrugalos::entity::object::{FragmentsSummary, ObjectVersion};
 use std::sync::Arc;
 use trackable::error::ErrorKindExt;
 
@@ -72,6 +72,19 @@ impl ReplicatedClient {
     /// TODO 実装
     pub fn head(self, _version: ObjectVersion, _deadline: Deadline) -> BoxFuture<()> {
         Box::new(futures::future::ok(()))
+    }
+    /// TODO 実装
+    pub fn count_fragments(
+        self,
+        _version: ObjectVersion,
+        _deadline: Deadline,
+    ) -> BoxFuture<FragmentsSummary> {
+        let summary = FragmentsSummary {
+            is_corrupted: false,
+            found_total: 0,
+            lost_total: 0,
+        };
+        Box::new(futures::future::ok(summary))
     }
     pub fn put(
         self,

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -6,7 +6,7 @@ use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_raft::NodeId;
 use futures::future;
 use futures::{self, Async, Future, Poll};
-use libfrugalos::entity::object::ObjectVersion;
+use libfrugalos::entity::object::{FragmentsSummary, ObjectVersion};
 use rustracing_jaeger::span::SpanHandle;
 use slog::Logger;
 use trackable::error::ErrorKindExt;
@@ -101,6 +101,22 @@ impl StorageClient {
             StorageClient::Metadata => Box::new(future::ok(())),
             StorageClient::Replicated(c) => c.head(version, deadline),
             StorageClient::Dispersed(c) => c.head(version, deadline, parent),
+        }
+    }
+    pub fn count_fragments(
+        self,
+        version: ObjectVersion,
+        deadline: Deadline,
+        parent: SpanHandle,
+    ) -> BoxFuture<FragmentsSummary> {
+        match self {
+            StorageClient::Metadata => Box::new(future::ok(FragmentsSummary {
+                is_corrupted: false,
+                found_total: 0,
+                lost_total: 0,
+            })),
+            StorageClient::Replicated(c) => c.count_fragments(version, deadline),
+            StorageClient::Dispersed(c) => c.count_fragments(version, deadline, parent),
         }
     }
     pub fn put(

--- a/frugalos_segment/src/config.rs
+++ b/frugalos_segment/src/config.rs
@@ -187,6 +187,14 @@ pub struct DispersedClientConfig {
     )]
     pub head_timeout: Duration,
 
+    /// How long to wait before aborting a count_fragments operation.
+    #[serde(
+        rename = "count_fragments_timeout_millis",
+        default = "default_dispersed_client_count_fragments_timeout",
+        with = "frugalos_core::serde_ext::duration_millis"
+    )]
+    pub count_fragments_timeout: Duration,
+
     /// Configuration for `CannyLsClient`.
     #[serde(flatten)]
     pub cannyls: CannyLsClientConfig,
@@ -197,6 +205,7 @@ impl Default for DispersedClientConfig {
         DispersedClientConfig {
             get_timeout: default_dispersed_client_get_timeout(),
             head_timeout: default_dispersed_client_head_timeout(),
+            count_fragments_timeout: default_dispersed_client_count_fragments_timeout(),
             cannyls: Default::default(),
         }
     }
@@ -207,6 +216,10 @@ fn default_dispersed_client_get_timeout() -> Duration {
 }
 
 fn default_dispersed_client_head_timeout() -> Duration {
+    Duration::from_secs(2)
+}
+
+fn default_dispersed_client_count_fragments_timeout() -> Duration {
     Duration::from_secs(2)
 }
 

--- a/it/testsuites/count_fragments.sh
+++ b/it/testsuites/count_fragments.sh
@@ -1,0 +1,68 @@
+#! /bin/bash
+
+set -eux
+
+source $(cd $(dirname $0); pwd)/common.sh
+
+CLUSTER=three-nodes
+
+#
+# Cleanups previous garbages
+#
+docker-compose -f it/clusters/${CLUSTER}.yml down
+sudo rm -rf /tmp/frugalos_it/
+
+#
+# Setups cluster
+#
+docker-compose -f it/clusters/${CLUSTER}.yml up -d
+mkdir -p ${WORK_DIR}
+sudo chmod 777 ${WORK_DIR}
+sleep 1
+HOST=frugalos03
+HOST_IP=`getent ahosts $HOST | head -1 | awk '{print $1}'`
+curl -f http://$HOST_IP/v1/servers | tee $WORK_DIR/servers.json
+SERVERS=`jq 'map(.id) | .[]' /tmp/frugalos_it/servers.json | sed -e 's/"//g'`
+
+#
+# Setups devices
+#
+it/scripts/put_devices.sh 1 $SERVERS
+
+#
+# Setups buckets
+#
+it/scripts/put_buckets.sh 1 2
+curl http://frugalos01/v1/buckets
+
+#
+# Puts objects
+#
+sleep 5
+curl -s -X PUT -d "test" "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1"
+sleep 5
+curl -s -X PUT -d "test" "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1"
+sleep 5
+
+#
+# 全台揃っている状況での GET
+#
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Corrupted: false"
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Found-Total: 3"
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Lost-Total: 0"
+
+#
+# ノードが 1 台停止中での GET
+#
+docker-compose -f it/clusters/${CLUSTER}.yml stop frugalos02
+# ハートビート間隔より長い時間待つ必要がある
+sleep 10
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Corrupted: false"
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Found-Total: 2"
+curl -s -I "http://$HOST_IP/v1/buckets/live_archive_chunk/objects/test1/fragments" | fgrep "FrugalOS-Fragments-Lost-Total: 1"
+
+#
+# Cleanups cluster
+#
+sleep 5
+docker-compose -f it/clusters/${CLUSTER}.yml down

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,8 @@ use futures::{self, Future};
 use libfrugalos::consistency::ReadConsistency;
 use libfrugalos::entity::bucket::BucketId;
 use libfrugalos::entity::object::{
-    DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
+    DeleteObjectsByPrefixSummary, FragmentsSummary, ObjectId, ObjectPrefix, ObjectSummary,
+    ObjectVersion,
 };
 use libfrugalos::expect::Expect;
 use rustracing_jaeger::span::{Span, SpanHandle};
@@ -121,6 +122,18 @@ impl<'a> Request<'a> {
         let segment = bucket.get_segment(&object_id);
         let future =
             segment.head_storage(object_id, self.deadline, consistency, self.parent.clone());
+        Box::new(future.map_err(|e| track!(Error::from(e))))
+    }
+    pub fn count_fragments(
+        &self,
+        object_id: ObjectId,
+        consistency: ReadConsistency,
+    ) -> BoxFuture<Option<FragmentsSummary>> {
+        let buckets = self.client.buckets.load();
+        let bucket = try_get_bucket!(buckets, self.bucket_id);
+        let segment = bucket.get_segment(&object_id);
+        let future =
+            segment.count_fragments(object_id, self.deadline, consistency, self.parent.clone());
         Box::new(future.map_err(|e| track!(Error::from(e))))
     }
     pub fn put(&self, object_id: ObjectId, content: Vec<u8>) -> BoxFuture<(ObjectVersion, bool)> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -64,7 +64,7 @@ pub fn make_object_response(
     version: Option<ObjectVersion>,
     body: Result<Vec<u8>>,
 ) -> Res<HttpResult<Vec<u8>>> {
-    // TODO `make_object_response` を `ObjectResponse` に置き換える
+    // TODO `make_object_response` の利用箇所を `ObjectResponse:new` を使うように変更する
     ObjectResponse::new(status, body)
         .version(version)
         .into_response()

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,6 @@
 use fibers_http_server::{Res, Status};
 use httpcodec::{Header, HeaderField, HeaderFields};
-use libfrugalos::entity::object::ObjectVersion;
+use libfrugalos::entity::object::{FragmentsSummary, ObjectVersion};
 use rustracing::carrier::IterHttpHeaderFields;
 use trackable::error::ErrorKindExt;
 
@@ -64,24 +64,10 @@ pub fn make_object_response(
     version: Option<ObjectVersion>,
     body: Result<Vec<u8>>,
 ) -> Res<HttpResult<Vec<u8>>> {
-    let mut res = match body {
-        Err(e) => {
-            let mut res = Res::new(status, HttpResult::Err(e));
-            res.header_mut().add_field(ContentTypeJson);
-            res
-        }
-        Ok(content) => {
-            let mut res = Res::new(status, HttpResult::Ok(content));
-            res.header_mut().add_field(ContentTypeOctetStream);
-            res
-        }
-    };
-    if let Some(version) = version {
-        res.header_mut().add_field(unsafe {
-            HeaderField::new_unchecked("ETag", &format!("\"{:x}\"", version.0))
-        });
-    }
-    res
+    // TODO `make_object_response` を `ObjectResponse` に置き換える
+    ObjectResponse::new(status, body)
+        .version(version)
+        .into_response()
 }
 
 pub fn not_found() -> Error {
@@ -92,4 +78,66 @@ pub fn not_found() -> Error {
 pub struct BucketStatistics {
     /// バケツ内のオブジェクト数.
     pub objects: u64,
+}
+
+#[derive(Debug)]
+pub struct ObjectResponse {
+    inner: Res<HttpResult<Vec<u8>>>,
+}
+impl ObjectResponse {
+    /// `ObjectResponse` を生成する.
+    pub fn new(status: Status, body: Result<Vec<u8>>) -> Self {
+        Self {
+            inner: match body {
+                Err(e) => {
+                    let mut res = Res::new(status, HttpResult::Err(e));
+                    res.header_mut().add_field(ContentTypeJson);
+                    res
+                }
+                Ok(content) => {
+                    let mut res = Res::new(status, HttpResult::Ok(content));
+                    res.header_mut().add_field(ContentTypeOctetStream);
+                    res
+                }
+            },
+        }
+    }
+    /// `ObjectVersion` をレスポンスにセットする.
+    pub fn version(mut self, version: Option<ObjectVersion>) -> Self {
+        if let Some(version) = version {
+            self.inner.header_mut().add_field(unsafe {
+                HeaderField::new_unchecked("ETag", &format!("\"{:x}\"", version.0))
+            });
+        }
+        self
+    }
+    /// `FragmentsSummary` をレスポンスにセットする.
+    pub fn fragments(mut self, fragments: Option<FragmentsSummary>) -> Self {
+        if let Some(fragments) = fragments {
+            let mut header = self.inner.header_mut();
+            header.add_field(unsafe {
+                HeaderField::new_unchecked(
+                    "FrugalOS-Fragments-Corrupted",
+                    &format!("{}", fragments.is_corrupted),
+                )
+            });
+            header.add_field(unsafe {
+                HeaderField::new_unchecked(
+                    "FrugalOS-Fragments-Found-Total",
+                    &format!("{}", fragments.found_total),
+                )
+            });
+            header.add_field(unsafe {
+                HeaderField::new_unchecked(
+                    "FrugalOS-Fragments-Lost-Total",
+                    &format!("{}", fragments.lost_total),
+                )
+            });
+        }
+        self
+    }
+    /// HTTP のレスポンスへと変換する.
+    pub fn into_response(self) -> Res<HttpResult<Vec<u8>>> {
+        self.inner
+    }
 }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -34,6 +34,7 @@ impl RpcServer {
         };
         builder.add_call_handler::<rpc::DeleteObjectRpc, _>(this.clone());
         builder.add_call_handler::<rpc::GetObjectRpc, _>(this.clone());
+        builder.add_call_handler::<rpc::CountFragmentsRpc, _>(this.clone());
         builder.add_call_handler::<rpc::HeadObjectRpc, _>(this.clone());
         builder.add_call_handler::<rpc::PutObjectRpc, _>(this.clone());
         builder.add_call_handler::<rpc::ListObjectsRpc, _>(this.clone());
@@ -151,6 +152,17 @@ impl HandleCall<rpc::GetObjectRpc> for RpcServer {
                 })
                 .then(Ok),
         )
+    }
+}
+impl HandleCall<rpc::CountFragmentsRpc> for RpcServer {
+    fn handle_call(&self, request: rpc::CountFragmentsRequest) -> Reply<rpc::CountFragmentsRpc> {
+        let future = self
+            .client
+            .request(request.bucket_id)
+            .deadline(into_cannyls_deadline(request.deadline))
+            .expect(request.expect)
+            .count_fragments(request.object_id, request.consistency);
+        Reply::future(future.map_err(into_rpc_error).then(Ok))
     }
 }
 impl HandleCall<rpc::HeadObjectRpc> for RpcServer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,7 @@ use fibers_http_server::{
     HandleRequest, Reply, Req, Res, ServerBuilder as HttpServerBuilder, Status,
 };
 use frugalos_core::tracer::ThreadLocalTracer;
+use futures::future::Either;
 use futures::{self, Future, Stream};
 use httpcodec::{BodyDecoder, BodyEncoder, HeadBodyEncoder, Header};
 use libfrugalos::consistency::ReadConsistency;
@@ -30,7 +31,8 @@ use url::Url;
 use client::FrugalosClient;
 use codec::{AsyncEncoder, ObjectResultEncoder};
 use http::{
-    make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader,
+    make_json_response, make_object_response, not_found, BucketStatistics, HttpResult,
+    ObjectResponse, TraceHeader,
 };
 use many_objects::put_many_objects;
 use {Error, ErrorKind, FrugalosConfig, Result};
@@ -97,6 +99,7 @@ impl Server {
         self.register_once_with_metrics(ListObjects(self.clone()), builder)?;
         self.register_once_with_metrics(GetObject(self.clone()), builder)?;
         self.register_once_with_metrics(HeadObject(self.clone()), builder)?;
+        self.register_once_with_metrics(HeadFragments(self.clone()), builder)?;
         self.register_once_with_metrics(DeleteObject(self.clone()), builder)?;
         self.register_once_with_metrics(DeleteObjectByPrefix(self.clone()), builder)?;
         self.register_once_with_metrics(PutObject(self.clone()), builder)?;
@@ -344,32 +347,38 @@ impl HandleRequest for HeadObject {
         let consistency = try_badarg!(get_consistency(&req.url()));
         let check_storage = try_badarg!(get_check_storage(&req.url()));
         let future = if check_storage {
-            self.0
-                .client
-                .request(bucket_id)
-                .deadline(deadline)
-                .expect(expect)
-                .span(&span)
-                .head_storage(object_id, consistency)
+            Either::A(
+                self.0
+                    .client
+                    .request(bucket_id)
+                    .deadline(deadline)
+                    .expect(expect)
+                    .span(&span)
+                    .head_storage(object_id, consistency),
+            )
         } else {
-            self.0
-                .client
-                .request(bucket_id)
-                .deadline(deadline)
-                .expect(expect)
-                .span(&span)
-                .head(object_id, consistency)
+            Either::B(
+                self.0
+                    .client
+                    .request(bucket_id)
+                    .deadline(deadline)
+                    .expect(expect)
+                    .span(&span)
+                    .head(object_id, consistency),
+            )
         };
         let future = future.then(move |result| {
             let response = match track!(result) {
                 Ok(None) => {
                     span.set_tag(|| StdTag::http_status_code(404));
-                    make_object_response(Status::NotFound, None, Err(not_found()))
+                    ObjectResponse::new(Status::NotFound, Err(not_found())).into_response()
                 }
                 Ok(Some(version)) => {
                     span.set_tag(|| Tag::new("object.version", version.0 as i64));
                     span.set_tag(|| StdTag::http_status_code(200));
-                    make_object_response(Status::Ok, Some(version), Ok(Vec::new()))
+                    ObjectResponse::new(Status::Ok, Ok(Vec::new()))
+                        .version(Some(version))
+                        .into_response()
                 }
                 // Err(ref e) if *e.kind() == frugalos::ErrorKind::NotFound => {
                 //     span.set_tag(|| StdTag::http_status_code(404));
@@ -384,11 +393,87 @@ impl HandleRequest for HeadObject {
                         e
                     );
                     span.set_tag(|| StdTag::http_status_code(500));
-                    make_object_response(Status::InternalServerError, None, Err(e))
+                    ObjectResponse::new(Status::InternalServerError, Err(e)).into_response()
                 }
             };
             Ok(response)
         });
+        Box::new(future)
+    }
+}
+
+struct HeadFragments(Server);
+impl HandleRequest for HeadFragments {
+    const METHOD: &'static str = "HEAD";
+    const PATH: &'static str = "/v1/buckets/*/objects/*/fragments";
+
+    type ReqBody = ();
+    type ResBody = HttpResult<Vec<u8>>;
+    type Decoder = BodyDecoder<NullDecoder>;
+    type Encoder = HeadBodyEncoder<BodyEncoder<ObjectResultEncoder>>;
+    type Reply = Reply<Self::ResBody>;
+
+    fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
+        let bucket_id = get_bucket_id(req.url());
+        let object_id = get_object_id(req.url());
+
+        let client_span = SpanContext::extract_from_http_header(&TraceHeader(req.header()))
+            .ok()
+            .and_then(|c| c);
+        let mut span = self
+            .0
+            .tracer
+            .span(|t| t.span("head_fragments").child_of(&client_span).start());
+        span.set_tag(|| StdTag::http_method("HEAD"));
+        span.set_tag(|| Tag::new("bucket.id", bucket_id.clone()));
+        span.set_tag(|| Tag::new("object.id", object_id.clone()));
+        // TODO: deadline and expect
+
+        let logger = self.0.logger.clone();
+        let expect = try_badarg!(get_expect(&req.header()));
+        let deadline = try_badarg!(get_deadline(&req.url()));
+        let consistency = try_badarg!(get_consistency(&req.url()));
+        let future = self
+            .0
+            .client
+            .request(bucket_id)
+            .deadline(deadline)
+            .expect(expect)
+            .span(&span)
+            .count_fragments(object_id, consistency)
+            .then(move |result| {
+                let response = match track!(result) {
+                    Ok(None) => {
+                        span.set_tag(|| StdTag::http_status_code(404));
+                        ObjectResponse::new(Status::NotFound, Err(not_found())).into_response()
+                    }
+                    Ok(Some(summary)) => {
+                        span.set_tag(|| Tag::new("fragments.is_corrupted", summary.is_corrupted));
+                        span.set_tag(|| {
+                            Tag::new("fragments.found_total", summary.found_total as i64)
+                        });
+                        span.set_tag(|| {
+                            Tag::new("fragments.lost_total", summary.lost_total as i64)
+                        });
+                        span.set_tag(|| StdTag::http_status_code(200));
+                        ObjectResponse::new(Status::Ok, Ok(Vec::new()))
+                            .fragments(Some(summary))
+                            .into_response()
+                    }
+                    Err(e) => {
+                        warn!(
+                            logger,
+                            "Cannot get fragments (bucket={:?}, object={:?}): {}",
+                            get_bucket_id(req.url()),
+                            get_object_id(req.url()),
+                            e
+                        );
+                        span.set_tag(|| StdTag::http_status_code(500));
+                        ObjectResponse::new(Status::InternalServerError, Err(e)).into_response()
+                    }
+                };
+                Ok(response)
+            });
         Box::new(future)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,7 +427,6 @@ impl HandleRequest for HeadFragments {
         span.set_tag(|| StdTag::http_method("HEAD"));
         span.set_tag(|| Tag::new("bucket.id", bucket_id.clone()));
         span.set_tag(|| Tag::new("object.id", object_id.clone()));
-        // TODO: deadline and expect
 
         let logger = self.0.logger.clone();
         let expect = try_badarg!(get_expect(&req.header()));


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

`HEAD /v1/buckets/*/objects/*/fragments` に HTTP リクエストを投げるとストレージに存在する/しないフラグメントの数を数えて結果を HTTP Header として返す。

HTTP レスポンスのステータスコードは、ストレージ上にフラグメントが `data_fragments` 個以上存在する/しないに関係なく `200` が返ってくる。フラグメントの存在確認中にエラーが発生した場合は `500` を返す。

HTTP レスポンスには以下のヘッダーが設定される:

`FrugalOS-Fragments-Corrupted`: 破損していたら true, 破損していなければ false
`FrugalOS-Fragments-Found-Total`: ストレージに存在しているフラグメント数
`FrugalOS-Fragments-Lost-Total`: ストレージに存在しないフラグメント数

### Purpose

オブジェクト ID を指定してそのオブジェクトのレプリカ数を調べるため。

fixes https://github.com/frugalos/frugalos/issues/242

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.