### PR TITLE
Reduces `repair_idleness_threshold` configuration change logs

### DIFF
--- a/frugalos_segment/src/queue_executor/repair_queue_executor.rs
+++ b/frugalos_segment/src/queue_executor/repair_queue_executor.rs
@@ -101,10 +101,6 @@ impl RepairQueueExecutor {
         &mut self,
         repair_idleness_threshold: RepairIdleness,
     ) {
-        info!(
-            self.logger,
-            "repair_idleness_threshold set to {:?}", repair_idleness_threshold,
-        );
         self.repair_idleness_threshold = repair_idleness_threshold;
     }
 }

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -108,6 +108,11 @@ where
     pub fn set_repair_config(&mut self, repair_config: RepairConfig) {
         // TODO: handle RepairConfig's remaining field (segment_gc_concurrency_limit)
         if let Some(repair_idleness_threshold) = repair_config.repair_idleness_threshold {
+            // https://github.com/frugalos/frugalos/issues/244
+            info!(
+                self.logger,
+                "repair_idleness_threshold set to {:?}", repair_idleness_threshold,
+            );
             for (_, segment_node_handle) in self.segment_node_handles.iter() {
                 let command =
                     SegmentNodeCommand::SetRepairIdlenessThreshold(repair_idleness_threshold);


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

各ノードに設定を通知する前に一度だけログを出す。

### Purpose

冗長なログが出ているため削減すること。 `slog` のログ上限が設定されているため他の重要なログを suppress してしまうので。

fixes https://github.com/frugalos/frugalos/issues/244

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.