### PR TITLE
Add new metrics to MdsClient

### DIFF
--- a/frugalos_segment/src/client/mds.rs
+++ b/frugalos_segment/src/client/mds.rs
@@ -88,9 +88,11 @@ use std::collections::hash_set::HashSet;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use trackable::error::ErrorKindExt;
 
 use config::{ClusterConfig, MdsClientConfig, MdsRequestPolicy};
+use metrics::MdsClientMetrics;
 use {Error, ErrorKind, ObjectValue, Result};
 
 // TODO HEAD/GET 以外の参照系リクエストで `ReadConsistency` をサポートする
@@ -100,6 +102,7 @@ pub struct MdsClient {
     rpc_service: RpcServiceHandle,
     inner: Arc<Mutex<Inner>>,
     client_config: MdsClientConfig,
+    metrics: MdsClientMetrics,
 }
 impl MdsClient {
     pub fn new(
@@ -107,6 +110,7 @@ impl MdsClient {
         rpc_service: RpcServiceHandle,
         cluster_config: ClusterConfig,
         client_config: MdsClientConfig,
+        metrics: MdsClientMetrics,
     ) -> Self {
         // TODO: 以下のassertionは復活させたい
         // assert!(!config.members.is_empty());
@@ -115,6 +119,7 @@ impl MdsClient {
             rpc_service,
             inner: Arc::new(Mutex::new(Inner::new(cluster_config))),
             client_config,
+            metrics,
         }
     }
 
@@ -557,10 +562,13 @@ impl Future for RequestTimeout {
 pub struct Request<T: RequestOnce> {
     client: MdsClient,
     max_retry: usize,
+    retries_total: usize,
     request: T,
     parent: SpanHandle,
     peers: Vec<NodeId>,
     timeout: RequestTimeout,
+    timeout_total: usize,
+    started_at: Instant,
     future: Option<BoxFuture<T::Item>>,
 }
 impl<T> Request<T>
@@ -574,10 +582,13 @@ where
         Request {
             client,
             max_retry,
+            retries_total: 0,
+            timeout_total: 0,
             request,
             parent,
             peers: Vec::new(),
             timeout,
+            started_at: Instant::now(),
             future: None,
         }
     }
@@ -589,6 +600,21 @@ where
         self.timeout = self.client.timeout(self.request.kind());
         self.future = Some(future);
         Ok(())
+    }
+    fn aggregate_metrics(&mut self) {
+        let elapsed = prometrics::timestamp::duration_to_seconds(self.started_at.elapsed());
+        self.client
+            .metrics
+            .request_duration_seconds
+            .observe(elapsed);
+        self.client
+            .metrics
+            .request_timeout_total
+            .observe(self.timeout_total as f64);
+        self.client
+            .metrics
+            .request_retries_total
+            .observe(self.retries_total as f64);
     }
 }
 impl<T> Future for Request<T>
@@ -602,14 +628,23 @@ where
         // It is possible to reduce processing time by making a request time out.
         // For example, there is a node where leader election has been completed but the leader has not been updated yet.
         while let Async::Ready(()) = track!(self.timeout.poll())? {
+            self.timeout_total += 1;
             warn!(
                 self.client.logger,
                 "Request timeout: peers={:?}, max_retry={}", self.peers, self.max_retry
             );
             self.client.clear_leader();
             if self.max_retry == 0 {
+                self.client
+                    .metrics
+                    .request_max_retry_reached_total
+                    .increment();
+                self.aggregate_metrics();
                 track_panic!(ErrorKind::Busy, "max retry reached: peers={:?}", self.peers);
             }
+            // NOTE: `request_once` はリトライ以外にも初回のリクエストでも呼ばれるため、
+            // `request_once` の外で計測する必要がある.
+            self.retries_total += 1;
             track!(self.request_once())?;
         }
         match self.future.poll() {
@@ -619,6 +654,7 @@ where
                     "Error: peers={:?}, reason={}", self.peers, e
                 );
                 if let MdsErrorKind::Unexpected(current) = *e.kind() {
+                    self.aggregate_metrics();
                     return Err(
                         track!(ErrorKind::UnexpectedVersion { current }.takes_over(e)).into(),
                     );
@@ -626,10 +662,16 @@ where
                     self.client.clear_leader();
                 }
                 if self.max_retry == 0 {
+                    self.client
+                        .metrics
+                        .request_max_retry_reached_total
+                        .increment();
+                    self.aggregate_metrics();
                     return Err(
                         track!(ErrorKind::Busy.takes_over(e), "peers={:?}", self.peers).into(),
                     );
                 }
+                self.retries_total += 1;
                 track!(self.request_once())?;
                 debug!(self.client.logger, "Tries next peers: {:?}", self.peers);
                 self.poll()
@@ -644,6 +686,7 @@ where
                     let (_addr, local_node_id) = leader;
                     self.client.set_leader(track!(local_node_id.parse())?);
                 }
+                self.aggregate_metrics();
                 Ok(Async::Ready(v))
             }
         }

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -17,10 +17,12 @@ use std::mem;
 use std::ops::Range;
 use SegmentStatistics;
 
+// TODO use の並び順を直す
 use self::ec::ErasureCoder;
 use self::mds::MdsClient;
 use self::storage::StorageClient;
 use config::ClientConfig;
+use metrics::MdsClientMetrics;
 use trackable::error::ErrorKindExt;
 use {Error, ErrorKind, ObjectValue, Result};
 
@@ -45,11 +47,13 @@ impl Client {
         config: ClientConfig,
         ec: Option<ErasureCoder>,
     ) -> Result<Self> {
+        let mds_client_metrics = track!(MdsClientMetrics::new())?;
         let mds = MdsClient::new(
             logger.clone(),
             rpc_service.clone(),
             config.cluster.clone(),
             config.mds.clone(),
+            mds_client_metrics,
         );
         let storage = track!(StorageClient::new(logger.clone(), config, rpc_service, ec))?;
         Ok(Client {

--- a/frugalos_segment/src/metrics.rs
+++ b/frugalos_segment/src/metrics.rs
@@ -1,8 +1,78 @@
 //! Metrics for `frugalos_segment`.
 
-use prometrics::metrics::{Counter, CounterBuilder};
+use prometrics::metrics::{Counter, CounterBuilder, Histogram, HistogramBuilder};
 
 use Result;
+
+#[derive(Debug, Clone)]
+pub struct MdsClientMetrics {
+    pub(crate) request_max_retry_reached_total: Counter,
+    pub(crate) request_retries_total: Histogram,
+    pub(crate) request_timeout_total: Histogram,
+    pub(crate) request_duration_seconds: Histogram,
+}
+impl MdsClientMetrics {
+    pub(crate) fn new() -> Result<Self> {
+        let request_max_retry_reached_total = track!(CounterBuilder::new(
+            "mds_client_request_max_retry_reached_total"
+        )
+        .namespace("frugalos")
+        .subsystem("segment")
+        .help("Number of MDS request retries")
+        .default_registry()
+        .finish())?;
+        let request_retries_total =
+            track!(HistogramBuilder::new("mds_client_request_retries_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("MDS request retries")
+                .bucket(0.0)
+                .bucket(1.0)
+                .bucket(2.0)
+                .bucket(3.0)
+                .bucket(4.0)
+                .bucket(5.0)
+                .default_registry()
+                .finish())?;
+        let request_timeout_total =
+            track!(HistogramBuilder::new("mds_client_request_timeout_total")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("MDS request timeout")
+                .bucket(0.0)
+                .bucket(1.0)
+                .bucket(2.0)
+                .bucket(3.0)
+                .bucket(4.0)
+                .bucket(5.0)
+                .default_registry()
+                .finish())?;
+        let request_duration_seconds =
+            track!(HistogramBuilder::new("mds_client_request_duration_seconds")
+                .namespace("frugalos")
+                .subsystem("segment")
+                .help("MDS request duration")
+                .bucket(0.001)
+                .bucket(0.005)
+                .bucket(0.01)
+                .bucket(0.05)
+                .bucket(0.1)
+                .bucket(0.5)
+                .bucket(1.0)
+                .bucket(2.0)
+                .bucket(3.0)
+                .bucket(4.0)
+                .bucket(5.0)
+                .default_registry()
+                .finish())?;
+        Ok(Self {
+            request_max_retry_reached_total,
+            request_retries_total,
+            request_timeout_total,
+            request_duration_seconds,
+        })
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct PutAllMetrics {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

以下のメトリクスを集計する:

`frugalos_segment_mds_client_request_retries_total`: 1リクエスト中にリトライが発生した回数
`frugalos_segment_mds_client_request_timeout_total`: 1リクエスト中にタイムアウトが発生した回数
`frugalos_segment_mds_client_request_duration_seconds`: リクエストの応答時間
`frugalos_segment_mds_client_request_max_retry_reached_total`: リトライ上限に到達した回数

### Purpose

MdsClient でタイムアウトやリトライが何度発生しているかを調べること。fixes #250 

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.