### PR TITLE
巨大オブジェクトの PUT 時にダンプしないようにする

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -548,14 +548,6 @@ impl HandleRequest for PutObject {
                 content.len(),
                 req.url()
             );
-            {
-                use std::fs::File;
-                use std::io::Write;
-
-                // TODO: 調査用の一時コード
-                let _ = File::create("/tmp/frugalos.huge.object.dump")
-                    .and_then(|mut f| f.write_all(&content));
-            }
             return Box::new(futures::finished(make_object_response(
                 Status::BadRequest,
                 None,


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
巨大なファイルを PUT したらエラーになるが、そのとき body がダンプされなくなる。
### Purpose
Fixes https://github.com/frugalos/frugalos/issues/255.
もう不要なため。
## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.