### PR TITLE
Delete also from repair_queue

### DIFF
--- a/frugalos_segment/src/queue_executor/repair_queue_executor.rs
+++ b/frugalos_segment/src/queue_executor/repair_queue_executor.rs
@@ -88,6 +88,13 @@ impl RepairQueueExecutor {
             self.enqueued_repair.increment();
         }
     }
+    /// Deletes an element from this queue.
+    /// This is typically called for deleted objects.
+    pub(crate) fn delete(&mut self, version: ObjectVersion) {
+        if self.queue.remove(&version) {
+            self.dequeued_repair.increment();
+        }
+    }
     fn pop(&mut self) -> Option<ObjectVersion> {
         // Pick the minimum element, if queue is not empty.
         let result = self.queue.iter().next().copied();

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -118,8 +118,9 @@ impl Synchronizer {
                 Event::Putted { .. } => {
                     self.general_queue.push(event);
                 }
-                Event::Deleted { .. } => {
+                Event::Deleted { version, .. } => {
                     self.general_queue.push(event);
+                    self.repair_queue.delete(version);
                 }
                 // Because pushing FullSync into the task queue causes difficulty in implementation,
                 // we decided not to push this task to the task priority queue and handle it manually.


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
DELETE がジャーナル (?) に記録されている場合や、後から DELETE が発行された場合にリペア対象から DELETE されたオブジェクトを除外する。
前者についてはどのくらいの頻度で起こるかは不明。後者は以下のようにして動作確認できる:
1. `scripts/setup_debug_cluster.sh` を実行する
2. オブジェクトを PUT する
3. サーバを 1 台止め、そのサーバの dev.lusf を消す
4. サーバを起動し、repair queue の長さが 1 になるのを待つ
    - `frugalos_synchronizer_enqueued_items{type="repair"} - frugalos_synchronizer_dequeued_items{type="repair"}` が 1 になれば良い
5. 2. で PUT したオブジェクトを消す
6. `frugalos_synchronizer_enqueued_items{type="repair"} - frugalos_synchronizer_dequeued_items{type="repair"}` が 0 になれば成功

### Purpose
Fixes https://github.com/frugalos/frugalos/issues/262.
## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.