### PR TITLE
set-repair-config コマンドに --segment-gc-concurrency-limit オプションを追加

### DIFF
--- a/src/command/set_repair_config.rs
+++ b/src/command/set_repair_config.rs
@@ -95,7 +95,6 @@ impl SetRepairConfigCommand {
             )));
             RepairConcurrencyLimit(limit)
         });
-        // TODO: accept segment_gc_concurrency_limit
         let segment_gc_concurrency_limit =
             matches.value_of(SEGMENT_GC_CONCURRENCY_LIMIT).map(|str| {
                 let limit: u64 = track_try_unwrap!(str.parse().map_err(|_| Error::from(


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
`frugalos set-repair-config` が `--segment-gc-concurrency-limit` オプションを受け取るようになる。例えば以下のように呼べる:
```
frugalos set-repair-config --segment-gc-concurrency-limit 1
```
### Purpose
segment_gc を有効にするため。この変更だけでは有効にできず、受け取る側も変更する必要がある。
## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.