### PR TITLE
segment_gc を呼び出し可能にする

### DIFF
--- a/frugalos_mds/src/lib.rs
+++ b/frugalos_mds/src/lib.rs
@@ -38,8 +38,8 @@ extern crate trackable;
 
 pub use config::FrugalosMdsConfig;
 pub use error::{Error, ErrorKind};
+use fibers::sync::oneshot::Monitored;
 pub use node::{Event, Node};
-pub use node::{StartSegmentGcReply, StopSegmentGcReply};
 pub use service::{Service, ServiceHandle};
 
 mod codec;
@@ -54,3 +54,8 @@ mod service;
 
 /// クレート固有の`Result`型.
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// StartSegmentGcReply で渡される tx の型。
+pub type StartSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + Sync>>;
+/// StopSegmentGcReply で渡される tx の型。
+pub type StopSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + Sync>>;

--- a/frugalos_mds/src/lib.rs
+++ b/frugalos_mds/src/lib.rs
@@ -39,6 +39,7 @@ extern crate trackable;
 pub use config::FrugalosMdsConfig;
 pub use error::{Error, ErrorKind};
 pub use node::{Event, Node};
+pub use node::{StartSegmentGcReply, StopSegmentGcReply};
 pub use service::{Service, ServiceHandle};
 
 mod codec;

--- a/frugalos_mds/src/node/handle.rs
+++ b/frugalos_mds/src/node/handle.rs
@@ -12,6 +12,7 @@ use std::ops::Range;
 use std::time::Instant;
 
 use super::{Reply, Request};
+use node::{StartSegmentGcReply, StopSegmentGcReply};
 use Error;
 
 macro_rules! future_try {
@@ -42,6 +43,14 @@ impl NodeHandle {
     }
     pub fn start_reelection(&self) {
         let _ = self.request_tx.send(Request::StartElection);
+    }
+    pub fn start_segment_gc(&self, tx: StartSegmentGcReply) {
+        let request = Request::StartSegmentGc(tx);
+        let _ = self.request_tx.send(request);
+    }
+    pub fn stop_segment_gc(&self, tx: StopSegmentGcReply) {
+        let request = Request::StopSegmentGc(tx);
+        let _ = self.request_tx.send(request);
     }
     pub fn get_leader(
         &self,

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -17,6 +17,7 @@ use {Error, ErrorKind, Result};
 
 pub use self::handle::NodeHandle;
 pub use self::node::Node;
+use {StartSegmentGcReply, StopSegmentGcReply};
 
 mod handle;
 mod metrics;
@@ -24,11 +25,6 @@ mod node;
 mod snapshot;
 
 pub(crate) type Reply<T> = Monitored<T, Error>;
-
-/// StartSegmentGcReply で渡される tx の型。
-pub type StartSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + 'static>>;
-/// StopSegmentGcReply で渡される tx の型。
-pub type StopSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + 'static>>;
 
 /// Raftに提案中のコマンド.
 #[derive(Debug)]

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -26,9 +26,9 @@ mod snapshot;
 pub(crate) type Reply<T> = Monitored<T, Error>;
 
 /// StartSegmentGcReply で渡される tx の型。
-pub type StartSegmentGcReply = fibers::sync::oneshot::Sender<()>;
+pub type StartSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + 'static>>;
 /// StopSegmentGcReply で渡される tx の型。
-pub type StopSegmentGcReply = fibers::sync::oneshot::Sender<()>;
+pub type StopSegmentGcReply = Monitored<(), Box<dyn std::error::Error + Send + 'static>>;
 
 /// Raftに提案中のコマンド.
 #[derive(Debug)]

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -236,11 +236,9 @@ impl Request {
             Request::DeleteByRange(_, _, tx) => tx.exit(Err(track!(e))),
             Request::DeleteByPrefix(_, tx) => tx.exit(Err(track!(e))),
             Request::Stop(tx) => tx.exit(Err(track!(e))),
-            Request::Exit
-            | Request::TakeSnapshot
-            | Request::StartElection
-            | Request::StartSegmentGc(_)
-            | Request::StopSegmentGc(_) => {}
+            Request::StartSegmentGc(tx) => tx.exit(Err(Box::new(track!(e)))),
+            Request::StopSegmentGc(tx) => tx.exit(Err(Box::new(track!(e)))),
+            Request::Exit | Request::TakeSnapshot | Request::StartElection => {}
         }
     }
 }

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -7,7 +7,6 @@ use libfrugalos::entity::object::{
 };
 use libfrugalos::expect::Expect;
 use libfrugalos::time::Seconds;
-use machine::Machine;
 use prometrics::metrics::{Counter, Histogram, MetricBuilder};
 use raftlog::log::LogIndex;
 use raftlog::log::ProposalId;
@@ -26,7 +25,9 @@ mod snapshot;
 
 pub(crate) type Reply<T> = Monitored<T, Error>;
 
+/// StartSegmentGcReply で渡される tx の型。
 pub type StartSegmentGcReply = fibers::sync::oneshot::Sender<()>;
+/// StopSegmentGcReply で渡される tx の型。
 pub type StopSegmentGcReply = fibers::sync::oneshot::Sender<()>;
 
 /// Raftに提案中のコマンド.

--- a/frugalos_mds/src/node/node.rs
+++ b/frugalos_mds/src/node/node.rs
@@ -29,6 +29,7 @@ use super::{Event, NodeHandle, Proposal, ProposalMetrics, Reply, Request, Second
 use codec;
 use config::FrugalosMdsConfig;
 use machine::{Command, Machine};
+use node::Event::{StartSegmentGc, StopSegmentGc};
 use protobuf;
 use std::cmp::Ordering;
 use {Error, ErrorKind, Result, ServiceHandle};
@@ -529,6 +530,15 @@ impl Node {
                     error!(self.logger, "Cannot take snapshot: {}", e);
                 }
             }
+            Request::StartSegmentGc(tx) => {
+                let object_versions = self.machine.to_versions();
+                self.events.push_back(StartSegmentGc {
+                    object_versions,
+                    next_commit: self.next_commit,
+                    tx,
+                })
+            }
+            Request::StopSegmentGc(tx) => {}
             Request::Exit => {
                 if self.phase == Phase::Stopping {
                     info!(self.logger, "Exit: node={:?}", self.node_id);

--- a/frugalos_mds/src/node/node.rs
+++ b/frugalos_mds/src/node/node.rs
@@ -340,7 +340,9 @@ impl Node {
             | Request::Exit
             | Request::Stop(_)
             | Request::TakeSnapshot
-            | Request::StartElection => {}
+            | Request::StartElection
+            | Request::StartSegmentGc(_)
+            | Request::StopSegmentGc(_) => {}
             _ => {
                 if let Err(e) = self.check_leader() {
                     request.failed(e);

--- a/frugalos_mds/src/node/node.rs
+++ b/frugalos_mds/src/node/node.rs
@@ -538,7 +538,9 @@ impl Node {
                     tx,
                 })
             }
-            Request::StopSegmentGc(tx) => {}
+            Request::StopSegmentGc(tx) => {
+                self.events.push_back(StopSegmentGc { tx });
+            }
             Request::Exit => {
                 if self.phase == Phase::Stopping {
                     info!(self.logger, "Exit: node={:?}", self.node_id);

--- a/frugalos_mds/src/service.rs
+++ b/frugalos_mds/src/service.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use node::NodeHandle;
 use server::Server;
 use {Error, Result};
+use {StartSegmentGcReply, StopSegmentGcReply};
 
 type Nodes = Arc<AtomicImmut<HashMap<LocalNodeId, NodeHandle>>>;
 
@@ -146,7 +147,7 @@ impl Service {
     /// After this command, mds sends to Synchronizer a command which contains the following:
     /// - machine
     /// - next_commit_id
-    pub fn start_segment_gc(&self, local_id: LocalNodeId, tx: fibers::sync::oneshot::Sender<()>) {
+    pub fn start_segment_gc(&self, local_id: LocalNodeId, tx: StartSegmentGcReply) {
         if let Some(node) = self.state.nodes().load().get(&local_id) {
             info!(
                 self.logger,
@@ -156,7 +157,7 @@ impl Service {
         }
     }
     /// Stops segment_gc on a single node.
-    pub fn stop_segment_gc(&self, local_id: LocalNodeId, tx: fibers::sync::oneshot::Sender<()>) {
+    pub fn stop_segment_gc(&self, local_id: LocalNodeId, tx: StopSegmentGcReply) {
         if let Some(node) = self.state.nodes().load().get(&local_id) {
             info!(
                 self.logger,

--- a/frugalos_mds/src/service.rs
+++ b/frugalos_mds/src/service.rs
@@ -155,6 +155,7 @@ impl Service {
             node.start_segment_gc(tx);
         }
     }
+    /// Stops segment_gc on a single node.
     pub fn stop_segment_gc(&self, local_id: LocalNodeId, tx: fibers::sync::oneshot::Sender<()>) {
         if let Some(node) = self.state.nodes().load().get(&local_id) {
             info!(

--- a/frugalos_mds/src/service.rs
+++ b/frugalos_mds/src/service.rs
@@ -154,6 +154,11 @@ impl Service {
                 "Sending segment_gc request to a single node: {:?}", local_id
             );
             node.start_segment_gc(tx);
+        } else {
+            warn!(
+                self.logger,
+                "Sending segment_gc request failed: local_node_id not found: {:?}", local_id
+            );
         }
     }
     /// Stops segment_gc on a single node.

--- a/frugalos_mds/src/service.rs
+++ b/frugalos_mds/src/service.rs
@@ -142,6 +142,28 @@ impl Service {
         }
     }
 
+    /// Performs segment_gc on a single node.
+    /// After this command, mds sends to Synchronizer a command which contains the following:
+    /// - machine
+    /// - next_commit_id
+    pub fn start_segment_gc(&self, local_id: LocalNodeId, tx: fibers::sync::oneshot::Sender<()>) {
+        if let Some(node) = self.state.nodes().load().get(&local_id) {
+            info!(
+                self.logger,
+                "Sending segment_gc request to a single node: {:?}", local_id
+            );
+            node.start_segment_gc(tx);
+        }
+    }
+    pub fn stop_segment_gc(&self, local_id: LocalNodeId, tx: fibers::sync::oneshot::Sender<()>) {
+        if let Some(node) = self.state.nodes().load().get(&local_id) {
+            info!(
+                self.logger,
+                "Stopping segment_gc of a single node: {:?}", local_id
+            );
+            node.stop_segment_gc(tx);
+        }
+    }
     fn handle_command(&mut self, command: Command) {
         match command {
             Command::AddNode(id, node) => {

--- a/frugalos_segment/src/error.rs
+++ b/frugalos_segment/src/error.rs
@@ -15,10 +15,15 @@ use trackable::error::{ErrorKind as TrackableErrorKind, ErrorKindExt};
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
 pub enum ErrorKind {
-    UnexpectedVersion { current: Option<ObjectVersion> },
+    UnexpectedVersion {
+        current: Option<ObjectVersion>,
+    },
     Invalid,
     Busy,
     Corrupted,
+
+    /// Monitor was aborted
+    MonitorAborted,
     Other,
 }
 impl TrackableErrorKind for ErrorKind {}

--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -47,6 +47,7 @@ mod queue_executor;
 mod repair;
 mod rpc_server;
 mod segment_gc;
+mod segment_gc_manager;
 mod service;
 mod synchronizer;
 mod test_util;

--- a/frugalos_segment/src/queue_executor/general_queue_executor.rs
+++ b/frugalos_segment/src/queue_executor/general_queue_executor.rs
@@ -47,7 +47,7 @@ impl TodoItem {
                     version,
                 }
             }
-            Event::FullSync { .. } => unreachable!(),
+            Event::StartSegmentGc { .. } | Event::StopSegmentGc { .. } => unreachable!(),
         }
     }
     pub fn wait_time(&self) -> Option<Duration> {
@@ -135,7 +135,7 @@ impl GeneralQueueExecutor {
                 self.repair_candidates.remove(&version);
                 self.delete_queue.push(version);
             }
-            Event::FullSync { .. } => {
+            Event::StartSegmentGc { .. } | Event::StopSegmentGc { .. } => {
                 unreachable!();
             }
         }

--- a/frugalos_segment/src/segment_gc.rs
+++ b/frugalos_segment/src/segment_gc.rs
@@ -20,7 +20,10 @@ pub(crate) struct SegmentGcMetrics {
     segment_gc_count: Counter,
     segment_gc_deleted_objects: Counter,
     // How many objects have to be swept before segment_gc is completed (including non-existent ones)
+    // TODO: 多数のノードがあっても正しく動くように、変更に set 以外を使う
     segment_gc_remaining: Gauge,
+    // How many jobs were aborted till now.
+    pub(crate) segment_gc_aborted: Counter,
 }
 
 impl SegmentGcMetrics {
@@ -36,6 +39,10 @@ impl SegmentGcMetrics {
                 .expect("metric should be well-formed"),
             segment_gc_remaining: metric_builder
                 .gauge("segment_gc_remaining")
+                .finish()
+                .expect("metric should be well-formed"),
+            segment_gc_aborted: metric_builder
+                .counter("segment_gc_aborted")
                 .finish()
                 .expect("metric should be well-formed"),
         }

--- a/frugalos_segment/src/segment_gc.rs
+++ b/frugalos_segment/src/segment_gc.rs
@@ -2,7 +2,6 @@ use cannyls::deadline::Deadline;
 use cannyls::device::DeviceHandle;
 use cannyls::lump::LumpId;
 use fibers_tasque::{DefaultCpuTaskQueue, TaskQueueExt};
-use frugalos_mds::machine::Machine;
 use frugalos_mds::StartSegmentGcReply;
 use frugalos_raft::NodeId;
 use futures::future::{join_all, loop_fn, ok, Either};
@@ -83,7 +82,10 @@ impl SegmentGc {
                     segment_gc_metrics.segment_gc_remaining,
                 )
             })
-            .map(move |()| info!(logger2, "SegmentGc objects done"));
+            .map(move |()| {
+                info!(logger2, "SegmentGc objects done");
+                let _ = tx.send(());
+            });
 
         let future = Box::new(combined_future);
         SegmentGc { future }

--- a/frugalos_segment/src/segment_gc.rs
+++ b/frugalos_segment/src/segment_gc.rs
@@ -145,7 +145,7 @@ pub(self) fn make_list_and_delete_content(
 ) -> impl Future<Item = (), Error = Error> + Send {
     if step == 0 {
         return Either::A(futures::future::err(
-            ErrorKind::Other.cause("step should be > 0").into(),
+            ErrorKind::Invalid.cause("step should be > 0").into(),
         ));
     }
     let logger = logger.clone();

--- a/frugalos_segment/src/segment_gc.rs
+++ b/frugalos_segment/src/segment_gc.rs
@@ -252,8 +252,7 @@ mod tests {
     use cannyls::device::DeviceHandle;
     use cannyls::lump::LumpId;
     use futures::future::Future;
-    use libfrugalos::entity::object::{Metadata, ObjectVersion};
-    use libfrugalos::expect::Expect;
+    use libfrugalos::entity::object::ObjectVersion;
     use segment_gc::{
         make_create_object_table, make_list_and_delete_content, ObjectTable, SegmentGc,
     };
@@ -264,7 +263,6 @@ mod tests {
 
     use config::make_lump_id;
     use fibers::executor::Executor;
-    use frugalos_mds::machine::Machine;
     use prometrics::metrics::{Counter, Gauge};
 
     #[test]
@@ -328,17 +326,12 @@ mod tests {
     #[test]
     fn create_object_table_lists_objects_correctly() -> TestResult {
         let logger = Logger::root(Discard, o!());
-        let mut machine = Machine::new();
+        let mut object_versions = Vec::new();
         for i in 0..10 {
-            let metadata = Metadata {
-                version: ObjectVersion(i),
-                data: vec![],
-            };
-
-            machine.put(format!("test-object-{}", i), metadata, &Expect::None)?;
+            object_versions.push(ObjectVersion(i));
         }
 
-        let create_object_table = make_create_object_table(logger, machine);
+        let create_object_table = make_create_object_table(logger, object_versions);
         let ObjectTable(result) = wait(create_object_table)?;
         assert_eq!(result.len(), 10);
         for (i, object_version) in result.into_iter().enumerate() {

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,9 +1,9 @@
 use futures::{Async, Future, Poll};
 use slog::Logger;
-use std::error::Error;
 
-pub(crate) type UnitFuture =
-    Box<dyn Future<Item = (), Error = Box<dyn Error + Send + 'static>> + Send + 'static>;
+use util::BoxFuture;
+
+pub(crate) type UnitFuture = BoxFuture<()>;
 
 /// 実行開始と停止ができる型
 pub(crate) trait Toggle {

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,0 +1,109 @@
+/// 実行開始と実行中かどうかの確認ができる型
+pub(crate) trait Toggle {
+    fn is_running(&self) -> bool;
+    fn start(&self);
+    fn stop(&self);
+}
+
+/// segment_gc の実行状況の管理を行う。
+/// これは SegmentService に管理され、SegmentService の指示によって segment_gc を開始したりする。
+/// Task は SegmentHandle のラッパを入れることを想定された型変数である。テストのしやすさのために多相型にしている。
+pub(crate) struct SegmentGcManager<Task> {
+    tasks: Vec<Task>,
+    running: Vec<usize>, // 実行中のタスクの番号の列
+    waiting: Vec<usize>, // 実行待ちのタスクの番号の列
+    limit: usize,        // 実行可能なタスク数の上限
+}
+
+impl<Task: Toggle> SegmentGcManager<Task> {
+    pub(crate) fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            running: Vec::new(),
+            waiting: Vec::new(),
+            limit: 0,
+        }
+    }
+    /// 初期化する。今まで覚えていたデータは失われる。
+    /// また今まで実行していたタスクも中断される。
+    pub(crate) fn init(&mut self, tasks: impl IntoIterator<Item = Task>) {
+        // Abort all tasks that were running
+        for &index in &self.running {
+            self.tasks[index].stop();
+        }
+        self.tasks = tasks.into_iter().collect();
+        self.running = Vec::new();
+        self.waiting = (0..self.tasks.len()).collect();
+    }
+
+    /// 実行数のリミットを設定する。すでに実行中のタスクがある場合、リミットに収まらない分は中断される。
+    pub(crate) fn set_limit(&mut self, limit: usize) {
+        self.limit = limit;
+        while self.running.len() > limit {
+            let index = self.running.pop().unwrap();
+            self.tasks[index].stop();
+            self.waiting.push(index);
+        }
+    }
+
+    /// 全タスクが終わったかどうかチェックする
+    pub(crate) fn is_done(&mut self) -> bool {
+        self.update_info();
+        self.running.is_empty() && self.waiting.is_empty()
+    }
+
+    /// この manager が持つ情報を最新にする。その結果 segment_gc の開始が必要そうならそうする。
+    fn update_info(&mut self) {
+        let new_running = self
+            .running
+            .iter()
+            .filter(|&&index| self.tasks[index].is_running())
+            .cloned()
+            .collect();
+        self.running = new_running;
+        // Fill in self.running with waiting tasks
+        while self.running.len() < self.limit {
+            if let Some(index) = self.waiting.pop() {
+                self.tasks[index].start();
+                self.running.push(index);
+            } else {
+                // No waiting tasks
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicI32, Ordering};
+    use std::sync::Arc;
+
+    struct IncrementToggle(Arc<AtomicI32>);
+
+    impl Toggle for IncrementToggle {
+        fn is_running(&self) -> bool {
+            false
+        }
+        fn start(&self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+        fn stop(&self) {}
+    }
+
+    #[test]
+    fn all_tasks_done() {
+        let count = 13;
+        let counter = Arc::new(AtomicI32::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..count {
+            tasks.push(IncrementToggle(Arc::clone(&counter)));
+        }
+        let mut manager = SegmentGcManager::new();
+        manager.init(tasks);
+        manager.set_limit(1);
+        while !manager.is_done() {}
+        assert_eq!(counter.load(Ordering::SeqCst), count);
+    }
+}

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,7 +1,7 @@
 use futures::{Async, Future, Poll};
 use slog::Logger;
 
-type UnitFuture = Box<dyn Future<Item = (), Error = ()>>;
+pub(crate) type UnitFuture = Box<dyn Future<Item = (), Error = ()>>;
 
 /// 実行開始と停止ができる型
 pub(crate) trait Toggle {

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,9 +1,7 @@
 use futures::{Async, Future, Poll};
 use slog::Logger;
 
-use util::BoxFuture;
-
-pub(crate) type UnitFuture = BoxFuture<()>;
+use util::UnitFuture;
 
 /// 実行開始と停止ができる型
 pub(crate) trait Toggle {

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,76 +1,105 @@
-/// 実行開始と実行中かどうかの確認ができる型
+use futures::{Async, Future, Poll};
+use slog::Logger;
+
+type UnitFuture = Box<dyn Future<Item = (), Error = ()>>;
+
+/// 実行開始と停止ができる型
 pub(crate) trait Toggle {
-    fn is_running(&self) -> bool;
-    fn start(&self);
-    fn stop(&self);
+    fn start(&self) -> UnitFuture;
+    fn stop(&self) -> UnitFuture;
 }
 
 /// segment_gc の実行状況の管理を行う。
 /// これは SegmentService に管理され、SegmentService の指示によって segment_gc を開始したりする。
 /// Task は SegmentHandle のラッパを入れることを想定された型変数である。テストのしやすさのために多相型にしている。
 pub(crate) struct SegmentGcManager<Task> {
+    logger: Logger,
     tasks: Vec<Task>,
-    running: Vec<usize>, // 実行中のタスクの番号の列
-    waiting: Vec<usize>, // 実行待ちのタスクの番号の列
-    limit: usize,        // 実行可能なタスク数の上限
+    running: Vec<(usize, UnitFuture)>,  // 実行中のタスクの番号の列
+    waiting: Vec<usize>,                // 実行待ちのタスクの番号の列
+    stopping: Vec<(usize, UnitFuture)>, // 停止中のタスクの番号の列
+    limit: usize,                       // 実行可能なタスク数の上限
 }
 
 impl<Task: Toggle> SegmentGcManager<Task> {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(logger: Logger) -> Self {
         Self {
+            logger,
             tasks: Vec::new(),
             running: Vec::new(),
             waiting: Vec::new(),
+            stopping: Vec::new(),
             limit: 0,
         }
     }
     /// 初期化する。今まで覚えていたデータは失われる。
     /// また今まで実行していたタスクも中断される。
+    /// タスクの実行中 (new してから set_limit をして、poll を始めた後) に呼んではいけない。
     pub(crate) fn init(&mut self, tasks: impl IntoIterator<Item = Task>) {
-        // Abort all tasks that were running
-        for &index in &self.running {
-            self.tasks[index].stop();
-        }
+        // タスクがどれも実行されていないという想定なので、単純に全て捨てる。
         self.tasks = tasks.into_iter().collect();
         self.running = Vec::new();
         self.waiting = (0..self.tasks.len()).collect();
+        self.stopping = Vec::new();
+        self.limit = 0;
     }
 
     /// 実行数のリミットを設定する。すでに実行中のタスクがある場合、リミットに収まらない分は中断される。
     pub(crate) fn set_limit(&mut self, limit: usize) {
         self.limit = limit;
         while self.running.len() > limit {
-            let index = self.running.pop().unwrap();
-            self.tasks[index].stop();
-            self.waiting.push(index);
+            let (index, _) = self.running.pop().unwrap();
+            let fut = self.tasks[index].stop();
+            self.stopping.push((index, fut));
         }
     }
+}
 
-    /// 全タスクが終わったかどうかチェックする
-    pub(crate) fn is_done(&mut self) -> bool {
-        self.update_info();
-        self.running.is_empty() && self.waiting.is_empty()
-    }
+impl<Task: Toggle> Future for SegmentGcManager<Task> {
+    type Item = ();
+    type Error = ();
 
-    /// この manager が持つ情報を最新にする。その結果 segment_gc の開始が必要そうならそうする。
-    fn update_info(&mut self) {
-        let new_running = self
-            .running
-            .iter()
-            .filter(|&&index| self.tasks[index].is_running())
-            .cloned()
-            .collect();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let mut new_running = Vec::new();
+        // running -> discarded
+        for (index, mut fut) in std::mem::replace(&mut self.running, Vec::new()) {
+            match fut.poll() {
+                Ok(Async::NotReady) => new_running.push((index, fut)),
+                Ok(Async::Ready(())) => (),
+                Err(_) => {
+                    // ログだけ吐いて握り潰す
+                    warn!(self.logger, "Error executing running: index = {}", index);
+                }
+            }
+        }
         self.running = new_running;
-        // Fill in self.running with waiting tasks
+        // stopping -> waiting
+        let mut new_stopping = Vec::new();
+        for (index, mut fut) in std::mem::replace(&mut self.stopping, Vec::new()) {
+            match fut.poll() {
+                Ok(Async::NotReady) => new_stopping.push((index, fut)),
+                Ok(Async::Ready(())) => self.waiting.push(index),
+                Err(_) => {
+                    // ログだけ吐いて握り潰す
+                    warn!(self.logger, "Error executing running: index = {}", index);
+                }
+            }
+        }
+        self.stopping = new_stopping;
+        // fill
         while self.running.len() < self.limit {
             if let Some(index) = self.waiting.pop() {
-                self.tasks[index].start();
-                self.running.push(index);
+                // start index
+                self.running.push((index, self.tasks[index].start()));
             } else {
-                // No waiting tasks
                 break;
             }
         }
+        // 全ての仕事が終わったかどうか確認する。
+        if self.running.is_empty() && self.waiting.is_empty() && self.stopping.is_empty() {
+            return Ok(Async::Ready(()));
+        }
+        Ok(Async::NotReady)
     }
 }
 
@@ -83,13 +112,13 @@ mod tests {
     struct IncrementToggle(Arc<AtomicI32>);
 
     impl Toggle for IncrementToggle {
-        fn is_running(&self) -> bool {
-            false
-        }
-        fn start(&self) {
+        fn start(&self) -> UnitFuture {
             self.0.fetch_add(1, Ordering::SeqCst);
+            Box::new(futures::future::ok(()))
         }
-        fn stop(&self) {}
+        fn stop(&self) -> UnitFuture {
+            Box::new(futures::future::ok(()))
+        }
     }
 
     #[test]
@@ -100,10 +129,30 @@ mod tests {
         for _ in 0..count {
             tasks.push(IncrementToggle(Arc::clone(&counter)));
         }
-        let mut manager = SegmentGcManager::new();
+        let logger = Logger::root(slog::Discard, o!());
+        let mut manager = SegmentGcManager::new(logger);
         manager.init(tasks);
         manager.set_limit(1);
-        while !manager.is_done() {}
+        while let Ok(Async::NotReady) = manager.poll() {}
         assert_eq!(counter.load(Ordering::SeqCst), count);
+    }
+
+    #[test]
+    fn no_tasks_will_be_done_if_limit_is_zero() {
+        let count = 13;
+        let counter = Arc::new(AtomicI32::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..count {
+            tasks.push(IncrementToggle(Arc::clone(&counter)));
+        }
+        let logger = Logger::root(slog::Discard, o!());
+        let mut manager = SegmentGcManager::new(logger);
+        manager.init(tasks);
+        manager.set_limit(0);
+        // 十分な回数 poll しても NotReady のまま
+        for _ in 0..1000 {
+            assert_eq!(Ok(Async::NotReady), manager.poll())
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
     }
 }

--- a/frugalos_segment/src/segment_gc_manager.rs
+++ b/frugalos_segment/src/segment_gc_manager.rs
@@ -1,7 +1,7 @@
 use futures::{Async, Future, Poll};
 use slog::Logger;
 
-pub(crate) type UnitFuture = Box<dyn Future<Item = (), Error = ()>>;
+pub(crate) type UnitFuture = Box<dyn Future<Item = (), Error = ()> + Send>;
 
 /// 実行開始と停止ができる型
 pub(crate) trait Toggle {

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -23,7 +23,7 @@ use trackable::error::ErrorKindExt;
 
 use client::storage::StorageClient;
 use rpc_server::RpcServer;
-use segment_gc_manager::{SegmentGcManager, Toggle};
+use segment_gc_manager::{GcTask, SegmentGcManager};
 use synchronizer::Synchronizer;
 use util::UnitFuture;
 use {Client, Error, ErrorKind, Result};
@@ -559,7 +559,7 @@ enum SegmentNodeCommand {
 /// machine の情報が欲しいため MdsService を経由しなければならない。
 struct SegmentGcToggle(ServiceHandle, LocalNodeId);
 
-impl Toggle for SegmentGcToggle {
+impl GcTask for SegmentGcToggle {
     fn start(&self) -> UnitFuture {
         let (tx, rx) = fibers::sync::oneshot::monitor();
         self.0.start_segment_gc(self.1, tx);

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -572,11 +572,11 @@ impl SegmentGcToggle {
     // rx を UnitFuture に変換するためのヘルパー関数。
     // polymorphism を導入しようとするとなぜか型エラーになる。(TODO: 解消)
     fn convert_rx_to_unit_future(
-        rx: Monitor<(), Box<dyn std::error::Error + Send + 'static>>,
+        rx: Monitor<(), Box<dyn std::error::Error + Send + Sync>>,
     ) -> UnitFuture {
         Box::new(rx.map_err(|e| match e {
-            MonitorError::Aborted => Box::new(ErrorKind::Other.error()),
-            MonitorError::Failed(e) => e,
+            MonitorError::Aborted => ErrorKind::MonitorAborted.error().into(),
+            MonitorError::Failed(e) => ErrorKind::Other.cause(e).into(),
         }))
     }
 }

--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -267,6 +267,7 @@ where
         match manager.poll() {
             Ok(Async::NotReady) => (),
             Ok(Async::Ready(())) => {
+                info!(self.logger, "Segment gc done");
                 self.segment_gc_manager = None;
             }
             Err(e) => {

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -136,14 +136,14 @@ impl Synchronizer {
                     self.general_queue.push(&event);
                     self.repair_queue.delete(version);
                 }
-                // Because pushing FullSync into the task queue causes difficulty in implementation,
+                // Because pushing StartSegmentGc into the task queue causes difficulty in implementation,
                 // we decided not to push this task to the task priority queue and handle it manually.
                 Event::StartSegmentGc {
                     object_versions,
                     next_commit,
                     tx,
                 } => {
-                    // If FullSync is not being processed now, this event lets the synchronizer to handle one.
+                    // If SegmentGc is not being processed now, this event lets the synchronizer to handle one.
                     if self.segment_gc.is_none() {
                         self.segment_gc = Some(SegmentGc::new(
                             &self.logger,
@@ -177,7 +177,7 @@ impl Future for Synchronizer {
             warn!(self.logger, "Task failure: {}", e);
             Async::Ready(Some(()))
         }) {
-            // Full sync is done. Clearing the segment_gc field.
+            // Segment GC is done. Clearing the segment_gc field.
             self.segment_gc = None;
             self.segment_gc_metrics.reset();
         }

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -159,7 +159,11 @@ impl Synchronizer {
                 }
                 Event::StopSegmentGc { tx } => {
                     // If segment gc is running, stop it without notifying its caller of stopping.
-                    self.segment_gc = None;
+                    if self.segment_gc.is_some() {
+                        self.segment_gc_metrics.segment_gc_aborted.increment();
+                        self.segment_gc = None;
+                        self.segment_gc_metrics.reset();
+                    }
                     // Notify stop's caller of success.
                     tx.exit(Ok(()));
                 }

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -106,7 +106,7 @@ impl Synchronizer {
             repair_queue,
         }
     }
-    pub fn handle_event(&mut self, event: &Event) {
+    pub fn handle_event(&mut self, event: Event) {
         debug!(
             self.logger,
             "New event: {:?} (metadata={})",
@@ -114,19 +114,20 @@ impl Synchronizer {
             self.client.is_metadata(),
         );
         if !self.client.is_metadata() {
-            match *event {
+            match event {
                 Event::Putted { .. } => {
-                    self.general_queue.push(event);
+                    self.general_queue.push(&event);
                 }
                 Event::Deleted { version, .. } => {
-                    self.general_queue.push(event);
+                    self.general_queue.push(&event);
                     self.repair_queue.delete(version);
                 }
                 // Because pushing FullSync into the task queue causes difficulty in implementation,
                 // we decided not to push this task to the task priority queue and handle it manually.
-                Event::FullSync {
-                    ref machine,
+                Event::StartSegmentGc {
+                    object_versions,
                     next_commit,
+                    tx,
                 } => {
                     // If FullSync is not being processed now, this event lets the synchronizer to handle one.
                     if self.segment_gc.is_none() {
@@ -134,13 +135,15 @@ impl Synchronizer {
                             &self.logger,
                             self.node_id,
                             &self.device,
-                            machine.clone(),
+                            object_versions.clone(),
                             ObjectVersion(next_commit.as_u64()),
                             self.segment_gc_metrics.clone(),
                             self.segment_gc_step,
+                            tx,
                         ));
                     }
                 }
+                Event::StopSegmentGc { .. } => unimplemented!(),
             }
         }
     }

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -117,7 +117,14 @@ impl Synchronizer {
         if self.client.is_metadata() {
             // metadata の場合、StartSegmentGc と StopSegmentGc に含まれている tx は処理しないといけないので処理する。
             match event {
-                Event::StartSegmentGc { tx, .. } | Event::StopSegmentGc { tx } => tx.exit(Ok(())),
+                Event::StartSegmentGc { tx, .. } => {
+                    info!(self.logger, "StartSegmentGc suppressed");
+                    tx.exit(Ok(()))
+                }
+                Event::StopSegmentGc { tx } => {
+                    info!(self.logger, "StopSegmentGc suppressed");
+                    tx.exit(Ok(()))
+                }
                 _ => (),
             }
         } else {

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -157,7 +157,12 @@ impl Synchronizer {
                         ));
                     }
                 }
-                Event::StopSegmentGc { .. } => unimplemented!(),
+                Event::StopSegmentGc { tx } => {
+                    // If segment gc is running, stop it without notifying its caller of stopping.
+                    self.segment_gc = None;
+                    // Notify stop's caller of success.
+                    tx.exit(Ok(()));
+                }
             }
         }
     }

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -149,7 +149,7 @@ impl Synchronizer {
                             &self.logger,
                             self.node_id,
                             &self.device,
-                            object_versions.clone(),
+                            object_versions,
                             ObjectVersion(next_commit.as_u64()),
                             self.segment_gc_metrics.clone(),
                             self.segment_gc_step,

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -113,7 +113,14 @@ impl Synchronizer {
             event,
             self.client.is_metadata(),
         );
-        if !self.client.is_metadata() {
+        // metadata かどうかによって場合分けする。
+        if self.client.is_metadata() {
+            // metadata の場合、StartSegmentGc と StopSegmentGc に含まれている tx は処理しないといけないので処理する。
+            match event {
+                Event::StartSegmentGc { tx, .. } | Event::StopSegmentGc { tx } => tx.exit(Ok(())),
+                _ => (),
+            }
+        } else {
             match event {
                 Event::Putted { .. } => {
                     self.general_queue.push(&event);

--- a/frugalos_segment/src/synchronizer.rs
+++ b/frugalos_segment/src/synchronizer.rs
@@ -118,11 +118,11 @@ impl Synchronizer {
             // metadata の場合、StartSegmentGc と StopSegmentGc に含まれている tx は処理しないといけないので処理する。
             match event {
                 Event::StartSegmentGc { tx, .. } => {
-                    info!(self.logger, "StartSegmentGc suppressed");
+                    debug!(self.logger, "StartSegmentGc suppressed");
                     tx.exit(Ok(()))
                 }
                 Event::StopSegmentGc { tx } => {
-                    info!(self.logger, "StopSegmentGc suppressed");
+                    debug!(self.logger, "StopSegmentGc suppressed");
                     tx.exit(Ok(()))
                 }
                 _ => (),

--- a/frugalos_segment/src/util.rs
+++ b/frugalos_segment/src/util.rs
@@ -55,3 +55,5 @@ where
 {
     Box::new(future.map_err(Error::from))
 }
+
+pub(crate) type UnitFuture = BoxFuture<()>;


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes
### Behavior
segment_gc_manager というモジュールを追加した。これにより、実行状況を管理しながら segment_gc が行われる。
- 正常時
`frugalos set-repair-config --segment-gc-concurrency-limit (同時実行数)` を実行した時の全 SegmentNode がキューに積まれ、順番に segment_gc が実行される。 最終的に全ての SegmentNode で segment_gc が実行されたら終了。同時に実行される segment_gc の個数はパラメータで指定できる。
- 途中で実行数を変えた時
現在実行中のオーバーしている分は即座に stop リクエストが呼ばれる。例えば、現在 3 並列で実行されているときに `frugalos set-repair-config --segment-gc-concurrency-limit 1` を実行したら、実行中の 2 個が選ばれ stop される。stop された分についてはまたキューに積まれ、最初から segment_gc のやり直しとなる。

### Purpose
segment_gc が呼べるようになる。これにより、デバイスファイルから不要なデータを消去できるようになる。
同時実行数も調節できるようにしているので、メモリや CPU の使いすぎになったら同時実行数を削減することで対策できる。

## TODO
- https://github.com/frugalos/frugalos/pull/269 がマージされたら base を develop に変える
- ~巨大な PR になったので、PR を分割した方が良い可能性がある。
frugalos_mds と frugalos_segment に変更を加えており、frugalos_mds の部分はほとんどロジック部分がないため、分離した方が見やすいかもしれない。~ 分離しない方が見やすいらしいので、分離しないことにした。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.