### PR TITLE
Update sloggers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 
 [[package]]
-name = "build_const"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-
-[[package]]
 name = "bytecodec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,15 +179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
 ]
 
 [[package]]
@@ -627,17 +612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9b4f294bb41a7f5333ab240eb33c71631378e32825d9db11f45e4ed0198325"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libflate"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
-dependencies = [
- "adler32",
- "byteorder",
- "crc",
 ]
 
 [[package]]
@@ -1110,16 +1084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog-kvfilter"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae939ed7d169eed9699f4f5cd440f046f5dc5dfc27c19e3cd311619594c175e0"
-dependencies = [
- "regex",
- "slog",
-]
-
-[[package]]
 name = "slog-scope"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,18 +1121,16 @@ dependencies = [
 
 [[package]]
 name = "sloggers"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1a15430a70a22ce2b066263dc55580a90b6920b837769332d2d0844a445549"
+checksum = "31bef221d42166d6708aa1e9b0182324b37a0a7517ff590ec201dbfe1cfa46ef"
 dependencies = [
  "chrono",
- "libflate",
  "regex",
  "serde",
  "serde_derive",
  "slog",
  "slog-async",
- "slog-kvfilter",
  "slog-scope",
  "slog-stdlog",
  "slog-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rustracing = "0.1"
 rustracing_jaeger = "0.1"
 siphasher = "0.2"
 slog = "2"
-sloggers = { version = "0.3.5", default-features = false, features = [] }
+sloggers = { version = "0.3.6", default-features = false, features = [] }
 serde = "1"
 serde_derive = "1"
 serde_ignored = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rustracing = "0.1"
 rustracing_jaeger = "0.1"
 siphasher = "0.2"
 slog = "2"
-sloggers = "0.3"
+sloggers = { version = "0.3.5", default-features = false, features = [] }
 serde = "1"
 serde_derive = "1"
 serde_ignored = "0.0.4"


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
変わらない。
### Purpose
`sloggers` を 0.3.1 から 0.3.6 へ upgrade する。それによって、今まで使われていなかった依存ライブラリが Cargo.lock から消える。
diff: https://github.com/sile/sloggers/compare/0.3.1...0.3.6

- https://github.com/sile/sloggers/pull/21
  - OverflowStrategy という機能を使っていないので、デフォルトの挙動のままのはず。
- https://github.com/sile/sloggers/commit/4b4e492c505b8267c6002353eb16af68787f7ecf
  - feature を全部 false にした状態で依存しているので、挙動に変化はない。
- https://github.com/sile/sloggers/pull/25
  - feature を全部 false にした状態で依存しているので、挙動に変化はない。
- https://github.com/sile/sloggers/pull/26
  - この機能を使っていないので関係ないはず。

Fix https://github.com/frugalos/frugalos/issues/264.

## Checklists
- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.