### PR TITLE
journal_region_ratio を環境変数で変更できるようにする

### DIFF
--- a/frugalos_config/src/cluster.rs
+++ b/frugalos_config/src/cluster.rs
@@ -73,7 +73,14 @@ pub fn make_rlog<P: AsRef<Path>, S: Spawn + Clone + Send + 'static>(
         100 * 1024 * 1024 // FIXME: パラメータ化
     ))?;
 
+    // Journal region のサイズの指定。デフォルトは 0.01。
+    // TODO: クラスタ構築時に指定できるようにする
+    let ratio: f64 = std::env::var("FRUGALOS_CLUSTER_DEVICE_JOURNAL_REGION_RATIO")
+        .map(|value| value.parse().unwrap())
+        .unwrap_or(0.01);
+
     let mut storage_builder = cannyls::storage::StorageBuilder::new();
+    storage_builder.journal_region_ratio(ratio);
     let metrics = MetricBuilder::new().label("device", "system").clone();
     storage_builder.metrics(metrics.clone());
     let storage = if created {

--- a/src/service.rs
+++ b/src/service.rs
@@ -408,7 +408,15 @@ fn spawn_file_device(device: &FileDeviceConfig) -> fibers_tasque::AsyncCall<Resu
         .clone();
     let filepath = device.filepath.clone();
     let capacity = device.capacity;
+
+    // Journal region のサイズの指定。デフォルトは 0.01。
+    // TODO: file device を PUT する時に指定できるようにする
+    let ratio: f64 = std::env::var("FRUGALOS_FILE_DEVICE_JOURNAL_REGION_RATIO")
+        .map(|value| value.parse().unwrap())
+        .unwrap_or(0.01);
+
     let mut storage = cannyls::storage::StorageBuilder::new();
+    storage.journal_region_ratio(ratio);
     storage.metrics(metrics.clone());
     fibers_tasque::DefaultIoTaskQueue.async_call(move || {
         let (nvm, created) =


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
`FRUGALOS_FILE_DEVICE_JOURNAL_REGION_RATIO` と `FRUGALOS_CLUSTER_DEVICE_JOURNAL_REGION_RATIO` という2種類の環境変数が読まれるようになる。それぞれ、ファイルデバイスの作成時、クラスタデバイスの作成時の [cannyls::storage::StorageBuilder::journal_region_ratio](https://docs.rs/cannyls/0.9.2/cannyls/storage/struct.StorageBuilder.html#method.journal_region_ratio) に渡される値として使われる。

### Purpose
Cannyls の journal region の大きさが frugalos の利用者から指定できないという問題があった。この PR では、それが一時的に解決される。最終的には設定ファイルで設定できるようにすべきである。

## 動作確認
`./scripts/setup_debug_cluster.sh` などを使用してファイルデバイス・クラスタデバイスを作り、`cannyls_storage_header` メトリクスを見て、`data_region_size` と `journal_region_size` の比が正しい値になっているか確認すれば良い。
手許で実行した結果は以下である:

frugalos 開始時のコマンド (`scripts/setup_debug_cluster.sh` の当該箇所に環境変数を追記):
```
FRUGALOS_CLUSTER_DEVICE_JOURNAL_REGION_RATIO=0.05 bin/frugalos create (省略)
FRUGALOS_FILE_DEVICE_JOURNAL_REGION_RATIO=0.1 FRUGALOS_SNAPSHOT_THRESHOLD=10 bin/frugalos start (省略)
```
メトリクス:
```
$ curl -s localhost:3100/metrics | grep cannyls_storage_header
# HELP cannyls_storage_header Header information of the storage
# TYPE cannyls_storage_header gauge
cannyls_storage_header{block_size="512",data_region_size="21805903360",device="srv0_dev0",journal_region_size="2422878720",uuid="21166ec5-835a-4ca3-af96-494a3a869bd8",version="1.1"} 1
cannyls_storage_header{block_size="512",data_region_size="99614208",device="system",journal_region_size="5242880",uuid="ad411206-d88c-499a-ab3b-44b51872bed8",version="1.1"} 1
```
## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.