### PR TITLE
Add fragment deletion API

### DIFF
--- a/frugalos_segment/src/client/dispersed_storage.rs
+++ b/frugalos_segment/src/client/dispersed_storage.rs
@@ -226,12 +226,11 @@ impl DispersedClient {
         parent: SpanHandle,
         index: usize,
     ) -> BoxFuture<bool> {
-        let mut candidates = self
+        let candidates = self
             .cluster
             .candidates(version)
             .cloned()
             .collect::<Vec<_>>();
-        candidates.reverse();
         let span = parent.child("delete_fragment", |span| {
             span.tag(StdTag::component(module_path!()))
                 .tag(Tag::new("object.version", version.0 as i64))

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -539,20 +539,25 @@ mod tests {
         ))?;
 
         for index in 0..3 {
-            let result = wait(client.delete_fragment(
+            if let Some((v, Some((b, _, _)))) = wait(client.delete_fragment(
                 object_id.to_owned(),
                 Deadline::Infinity,
                 Span::inactive().handle(),
                 index,
-            ))?;
-            assert_eq!(result, Some(object_version));
-            let result = wait(client.delete_fragment(
+            ))? {
+                assert_eq!(v, object_version);
+                assert_eq!(b, true);
+            }
+
+            if let Some((v, Some((b, _, _)))) = wait(client.delete_fragment(
                 object_id.to_owned(),
                 Deadline::Infinity,
                 Span::inactive().handle(),
                 index,
-            ))?;
-            assert_eq!(result, None);
+            ))? {
+                assert_eq!(v, object_version);
+                assert_eq!(b, false);
+            }
         }
 
         let result = wait(client.head(

--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -209,7 +209,7 @@ impl Client {
         self.mds.delete_by_prefix(prefix, parent)
     }
 
-    /// オブジェクトの実体を構成するフラグメントのみを削除する
+    /// オブジェクトのフラグメントのみを削除する
     pub fn delete_fragment(
         &self,
         id: ObjectId,

--- a/frugalos_segment/src/client/replicated_storage.rs
+++ b/frugalos_segment/src/client/replicated_storage.rs
@@ -122,12 +122,11 @@ impl ReplicatedClient {
         deadline: Deadline,
         index: usize,
     ) -> BoxFuture<bool> {
-        let mut candidates = self
+        let candidates = self
             .cluster
             .candidates(version)
             .cloned()
             .collect::<Vec<_>>();
-        candidates.reverse();
         if candidates.len() <= index {
             return Box::new(futures::future::ok(false));
         }
@@ -139,8 +138,7 @@ impl ReplicatedClient {
         let device = cluster_member.device;
         let future = request
             .deadline(deadline)
-            .delete_lump(DeviceId::new(device), lump_id)
-            .then(move |result| result);
+            .delete_lump(DeviceId::new(device), lump_id);
         Box::new(future.map_err(|e| track!(Error::from(e))))
     }
 }

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -116,6 +116,19 @@ impl StorageClient {
             StorageClient::Dispersed(c) => c.put(version, content, deadline, parent),
         }
     }
+    pub fn delete_fragment(
+        self,
+        version: ObjectVersion,
+        deadline: Deadline,
+        parent: SpanHandle,
+        index: usize,
+    ) -> BoxFuture<bool> {
+        match self {
+            StorageClient::Metadata => Box::new(future::ok(false)),
+            StorageClient::Replicated(c) => c.delete_fragment(version, deadline, index),
+            StorageClient::Dispersed(c) => c.delete_fragment(version, deadline, parent, index),
+        }
+    }
 }
 
 pub struct PutAll {

--- a/frugalos_segment/src/client/storage.rs
+++ b/frugalos_segment/src/client/storage.rs
@@ -2,6 +2,8 @@
 use adler32;
 use byteorder::{BigEndian, ByteOrder};
 use cannyls::deadline::Deadline;
+use cannyls::lump::LumpId;
+use cannyls_rpc::DeviceId;
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_raft::NodeId;
 use futures::future;
@@ -122,9 +124,9 @@ impl StorageClient {
         deadline: Deadline,
         parent: SpanHandle,
         index: usize,
-    ) -> BoxFuture<bool> {
+    ) -> BoxFuture<Option<(bool, DeviceId, LumpId)>> {
         match self {
-            StorageClient::Metadata => Box::new(future::ok(false)),
+            StorageClient::Metadata => Box::new(future::ok(None)),
             StorageClient::Replicated(c) => c.delete_fragment(version, deadline, index),
             StorageClient::Dispersed(c) => c.delete_fragment(version, deadline, parent, index),
         }

--- a/it/testsuites/delete_fragment.sh
+++ b/it/testsuites/delete_fragment.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+set -eux
+
+source $(cd $(dirname $0); pwd)/common.sh
+
+CLUSTER=three-nodes
+HOST=frugalos01
+BUCKET_ID=live_archive_chunk
+
+#
+# Cleanups previous garbages
+#
+docker-compose -f it/clusters/${CLUSTER}.yml down
+sudo rm -rf ${WORK_DIR}
+
+#
+# Setups cluster
+#
+docker-compose -f it/clusters/${CLUSTER}.yml up -d
+mkdir -p ${WORK_DIR}
+sudo chmod 777 ${WORK_DIR}
+sleep 1
+curl -f http://${HOST}/v1/servers | tee ${WORK_DIR}/servers.json
+SERVERS=`jq 'map(.id) | .[]' /tmp/frugalos_it/servers.json | sed -e 's/"//g'`
+
+#
+# Setups devices
+#
+it/scripts/put_devices.sh 1 ${SERVERS}
+
+#
+# Setups buckets
+#
+it/scripts/put_buckets.sh 1 2
+curl http://frugalos01/v1/buckets
+
+function curl_assert() {
+    local ARGS=$1
+    local EXPECT_STATUS=$2
+    [ $EXPECT_STATUS -eq `curl -o /dev/null -s -w "%{http_code}\n" $ARGS` ]
+}
+
+# put
+sleep 30
+curl_assert "-X PUT -d 'foo' http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "201"
+
+# head/get
+curl_assert "-I -s http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "200"
+curl_assert "-s http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "200"
+
+# delete_fragment
+curl_assert "-X DELETE http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo/fragments/0" "200"
+curl_assert "-X DELETE http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo/fragments/1" "200"
+
+# head/get
+curl_assert "-I -s http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "200"
+curl_assert "-s http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "500"
+
+docker-compose -f it/clusters/${CLUSTER}.yml down

--- a/it/testsuites/delete_fragment.sh
+++ b/it/testsuites/delete_fragment.sh
@@ -42,7 +42,7 @@ function curl_assert() {
 }
 
 # put
-sleep 30
+sleep 20
 curl_assert "-X PUT -d 'foo' http://${HOST}/v1/buckets/${BUCKET_ID}/objects/foo" "201"
 
 # head/get

--- a/src/client.rs
+++ b/src/client.rs
@@ -206,6 +206,7 @@ impl<'a> Request<'a> {
             DeleteObjectsByPrefixSummary { total }
         }))
     }
+    #[allow(clippy::type_complexity)]
     pub fn delete_fragment(
         &self,
         object_id: ObjectId,

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::needless_pass_by_value)]
 use atomic_immut::AtomicImmut;
 use cannyls::deadline::Deadline;
+use cannyls::lump::LumpId;
+use cannyls_rpc::DeviceId;
 use frugalos_segment::ObjectValue;
 use futures::{self, Future};
 use libfrugalos::consistency::ReadConsistency;
@@ -208,7 +210,7 @@ impl<'a> Request<'a> {
         &self,
         object_id: ObjectId,
         index: usize,
-    ) -> BoxFuture<Option<ObjectVersion>> {
+    ) -> BoxFuture<Option<(ObjectVersion, Option<(bool, DeviceId, LumpId)>)>> {
         let buckets = self.client.buckets.load();
         let bucket = try_get_bucket!(buckets, self.bucket_id);
         let segment = bucket.get_segment(&object_id);

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,6 +204,18 @@ impl<'a> Request<'a> {
             DeleteObjectsByPrefixSummary { total }
         }))
     }
+    pub fn delete_fragment(
+        &self,
+        object_id: ObjectId,
+        index: usize,
+    ) -> BoxFuture<Option<ObjectVersion>> {
+        let buckets = self.client.buckets.load();
+        let bucket = try_get_bucket!(buckets, self.bucket_id);
+        let segment = bucket.get_segment(&object_id);
+        let future = segment.delete_fragment(object_id, self.deadline, self.parent.clone(), index);
+        Box::new(future.map_err(|e| track!(Error::from(e))))
+    }
+
     pub fn list(&self, segment: usize) -> BoxFuture<Vec<ObjectSummary>> {
         let buckets = self.client.buckets.load();
         let bucket = try_get_bucket!(buckets, self.bucket_id);

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ impl From<frugalos_segment::Error> for Error {
     fn from(f: frugalos_segment::Error) -> Self {
         if let frugalos_segment::ErrorKind::UnexpectedVersion { current } = *f.kind() {
             ErrorKind::Unexpected(current).takes_over(f).into()
+        } else if let frugalos_segment::ErrorKind::Invalid = *f.kind() {
+            ErrorKind::InvalidInput.takes_over(f).into()
         } else {
             ErrorKind::Other.takes_over(f).into()
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -116,7 +116,7 @@ impl DeleteFragmentResponse {
             version: format!("{:x}", version.0),
             deleted,
             device_id: device_id.into_string(),
-            lump_id: format!("{:>032x}", lump_id.as_u128()),
+            lump_id: lump_id.to_string(),
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,5 @@
+use cannyls::lump::LumpId;
+use cannyls_rpc::DeviceId;
 use fibers_http_server::{Res, Status};
 use httpcodec::{Header, HeaderField, HeaderFields};
 use libfrugalos::entity::object::ObjectVersion;
@@ -92,4 +94,29 @@ pub fn not_found() -> Error {
 pub struct BucketStatistics {
     /// バケツ内のオブジェクト数.
     pub objects: u64,
+}
+
+#[derive(Serialize, Debug)]
+pub struct DeleteFragmentResponse {
+    pub version: String,
+    /// 実際に削除が実行されたか
+    pub deleted: bool,
+    pub device_id: String,
+    pub lump_id: String,
+}
+
+impl DeleteFragmentResponse {
+    pub fn new(
+        version: ObjectVersion,
+        deleted: bool,
+        device_id: DeviceId,
+        lump_id: LumpId,
+    ) -> Self {
+        Self {
+            version: format!("{:x}", version.0),
+            deleted: deleted,
+            device_id: device_id.into_string(),
+            lump_id: format!("{:>032x}", lump_id.as_u128()),
+        }
+    }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -114,7 +114,7 @@ impl DeleteFragmentResponse {
     ) -> Self {
         Self {
             version: format!("{:x}", version.0),
-            deleted: deleted,
+            deleted,
             device_id: device_id.into_string(),
             lump_id: format!("{:>032x}", lump_id.as_u128()),
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,7 +30,8 @@ use url::Url;
 use client::FrugalosClient;
 use codec::{AsyncEncoder, ObjectResultEncoder};
 use http::{
-    make_json_response, make_object_response, not_found, BucketStatistics, HttpResult, TraceHeader,
+    make_json_response, make_object_response, not_found, BucketStatistics, DeleteFragmentResponse,
+    HttpResult, TraceHeader,
 };
 use many_objects::put_many_objects;
 use {Error, ErrorKind, FrugalosConfig, Result};
@@ -538,9 +539,9 @@ impl HandleRequest for DeleteFragment {
     const PATH: &'static str = "/v1/buckets/*/objects/*/fragments/*";
 
     type ReqBody = ();
-    type ResBody = HttpResult<Vec<u8>>;
+    type ResBody = HttpResult<DeleteFragmentResponse>;
     type Decoder = BodyDecoder<NullDecoder>;
-    type Encoder = BodyEncoder<ObjectResultEncoder>;
+    type Encoder = BodyEncoder<JsonEncoder<Self::ResBody>>;
     type Reply = Reply<Self::ResBody>;
 
     fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
@@ -570,20 +571,32 @@ impl HandleRequest for DeleteFragment {
             .span(&span)
             .delete_fragment(object_id, fragment_index)
             .then(move |result| {
-                let response = match track!(result) {
+                let (status, body) = match track!(result) {
                     Ok(None) => {
                         span.set_tag(|| StdTag::http_status_code(404));
-                        make_object_response(Status::NotFound, None, Err(not_found()))
+                        (Status::NotFound, Err(not_found()))
                     }
-                    Ok(Some(version)) => {
+                    Ok(Some((version, result))) => {
                         span.set_tag(|| Tag::new("object.version", version.0 as i64));
                         span.set_tag(|| StdTag::http_status_code(200));
-                        make_object_response(Status::Ok, Some(version), Ok(Vec::new()))
+                        if let Some((deleted, device_id, lump_id)) = result {
+                            (
+                                Status::Ok,
+                                Ok(DeleteFragmentResponse::new(
+                                    version, deleted, device_id, lump_id,
+                                )),
+                            )
+                        } else {
+                            (Status::NotFound, Err(not_found()))
+                        }
                     }
                     Err(e) => {
-                        if let ErrorKind::Unexpected(version) = *e.kind() {
+                        if let ErrorKind::InvalidInput = *e.kind() {
+                            span.set_tag(|| StdTag::http_status_code(400));
+                            (Status::BadRequest, Err(e))
+                        } else if let ErrorKind::Unexpected(_version) = *e.kind() {
                             span.set_tag(|| StdTag::http_status_code(412));
-                            make_object_response(Status::PreconditionFailed, version, Err(e))
+                            (Status::PreconditionFailed, Err(e))
                         } else {
                             warn!(
                                 logger,
@@ -593,11 +606,11 @@ impl HandleRequest for DeleteFragment {
                                 e
                             );
                             span.set_tag(|| StdTag::http_status_code(500));
-                            make_object_response(Status::InternalServerError, None, Err(e))
+                            (Status::InternalServerError, Err(e))
                         }
                     }
                 };
-                Ok(response)
+                Ok(make_json_response(status, body))
             });
         Box::new(future)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -99,6 +99,7 @@ impl Server {
         self.register_once_with_metrics(HeadObject(self.clone()), builder)?;
         self.register_once_with_metrics(DeleteObject(self.clone()), builder)?;
         self.register_once_with_metrics(DeleteObjectByPrefix(self.clone()), builder)?;
+        self.register_once_with_metrics(DeleteFragment(self.clone()), builder)?;
         self.register_once_with_metrics(PutObject(self.clone()), builder)?;
         self.register_once_with_metrics(PutManyObject(self.clone()), builder)?;
         self.register_once_with_metrics(GetBucketStatistics(self.clone()), builder)?;
@@ -423,6 +424,7 @@ impl HandleRequest for DeleteObject {
         let logger = self.0.logger.clone();
         let expect = try_badarg!(get_expect(&req.header()));
         let deadline = try_badarg!(get_deadline(&req.url()));
+
         let future = self
             .0
             .client
@@ -522,6 +524,77 @@ impl HandleRequest for DeleteObjectByPrefix {
                         );
                         span.set_tag(|| StdTag::http_status_code(500));
                         make_json_response(Status::InternalServerError, Err(e))
+                    }
+                };
+                Ok(response)
+            });
+        Box::new(future)
+    }
+}
+
+struct DeleteFragment(Server);
+impl HandleRequest for DeleteFragment {
+    const METHOD: &'static str = "DELETE";
+    const PATH: &'static str = "/v1/buckets/*/objects/*/fragments/*";
+
+    type ReqBody = ();
+    type ResBody = HttpResult<Vec<u8>>;
+    type Decoder = BodyDecoder<NullDecoder>;
+    type Encoder = BodyEncoder<ObjectResultEncoder>;
+    type Reply = Reply<Self::ResBody>;
+
+    fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
+        let bucket_id = get_bucket_id(req.url());
+        let object_id = get_object_id(req.url());
+        let fragment_index = try_badarg_option!(try_badarg!(get_fragment_index(req.url())));
+
+        let client_span = SpanContext::extract_from_http_header(&TraceHeader(req.header()))
+            .ok()
+            .and_then(|c| c);
+        let mut span = self
+            .0
+            .tracer
+            .span(|t| t.span("delete_fragment").child_of(&client_span).start());
+        span.set_tag(|| StdTag::http_method("DELETE"));
+        span.set_tag(|| Tag::new("bucket.id", bucket_id.clone()));
+        span.set_tag(|| Tag::new("object.id", object_id.clone()));
+
+        let logger = self.0.logger.clone();
+        let deadline = try_badarg!(get_deadline(&req.url()));
+
+        let future = self
+            .0
+            .client
+            .request(bucket_id)
+            .deadline(deadline)
+            .span(&span)
+            .delete_fragment(object_id, fragment_index)
+            .then(move |result| {
+                let response = match track!(result) {
+                    Ok(None) => {
+                        span.set_tag(|| StdTag::http_status_code(404));
+                        make_object_response(Status::NotFound, None, Err(not_found()))
+                    }
+                    Ok(Some(version)) => {
+                        span.set_tag(|| Tag::new("object.version", version.0 as i64));
+                        span.set_tag(|| StdTag::http_status_code(200));
+                        make_object_response(Status::Ok, Some(version), Ok(Vec::new()))
+                    }
+                    Err(e) => {
+                        if let ErrorKind::Unexpected(version) = *e.kind() {
+                            span.set_tag(|| StdTag::http_status_code(412));
+                            make_object_response(Status::PreconditionFailed, version, Err(e))
+                        } else {
+                            warn!(
+                                logger,
+                                "Cannot delete object fragment (bucket={:?}, object={:?}): {}",
+                                get_bucket_id(req.url()),
+                                get_object_id(req.url()),
+                                e
+                            );
+                            span.set_tag(|| StdTag::http_status_code(500));
+                            make_object_response(Status::InternalServerError, None, Err(e))
+                        }
                     }
                 };
                 Ok(response)
@@ -907,6 +980,15 @@ fn get_usize_option(url: &Url, option_name: &str) -> Result<Option<usize>> {
         }
     }
     Ok(None)
+}
+
+fn get_fragment_index(url: &Url) -> Result<Option<usize>> {
+    let fragment_index = url.path_segments().expect("Never fails").nth(6);
+    if let Some(v) = fragment_index {
+        return track!(v.parse::<usize>().map_err(Error::from).map(Some));
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

#241 

- `DELETE /v1/buckets/*/objects/*/fragments/*` で指定のフラグメントを削除

### Purpose

- リペアや `HEAD` の動作確認に利用

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.