### PR TITLE
Outputs a log when a leader is absent for a long term

### DIFF
--- a/frugalos_mds/src/config.rs
+++ b/frugalos_mds/src/config.rs
@@ -32,6 +32,16 @@ pub struct FrugalosMdsConfig {
     #[serde(default = "default_leader_waiting_timeout_threshold")]
     pub leader_waiting_timeout_threshold: usize,
 
+    /// true ならリーダー不在状況でログを出す。
+    #[serde(default = "default_log_leader_absence")]
+    pub log_leader_absence: bool,
+
+    /// リーダー不在状況でログを出すまでの閾値。
+    ///
+    /// この設定値の1単位は `node_polling_interval` である点に注意。
+    #[serde(default = "default_log_leader_absence_threshold")]
+    pub log_leader_absence_threshold: usize,
+
     /// node がポーリングする間隔。
     #[serde(
         rename = "node_polling_interval_millis",
@@ -80,6 +90,8 @@ impl Default for FrugalosMdsConfig {
             large_proposal_queue_threshold: default_large_proposal_queue_threshold(),
             large_leader_waiting_queue_threshold: default_large_leader_waiting_queue_threshold(),
             leader_waiting_timeout_threshold: default_leader_waiting_timeout_threshold(),
+            log_leader_absence: default_log_leader_absence(),
+            log_leader_absence_threshold: default_log_leader_absence_threshold(),
             node_polling_interval: default_node_polling_interval(),
             reelection_threshold: default_reelection_threshold(),
             snapshot_threshold_min: default_snapshot_threshold_min(),
@@ -103,6 +115,14 @@ fn default_large_leader_waiting_queue_threshold() -> usize {
 
 fn default_leader_waiting_timeout_threshold() -> usize {
     10
+}
+
+fn default_log_leader_absence() -> bool {
+    false
+}
+
+fn default_log_leader_absence_threshold() -> usize {
+    600 // 5 minutes
 }
 
 fn default_node_polling_interval() -> Duration {

--- a/frugalos_mds/src/node/mod.rs
+++ b/frugalos_mds/src/node/mod.rs
@@ -23,6 +23,7 @@ mod handle;
 mod metrics;
 mod node;
 mod snapshot;
+mod timeout;
 
 pub(crate) type Reply<T> = Monitored<T, Error>;
 

--- a/frugalos_mds/src/node/timeout.rs
+++ b/frugalos_mds/src/node/timeout.rs
@@ -1,0 +1,60 @@
+/// 一定値ずつ減少していくタイムアウト値。
+#[derive(Debug)]
+pub struct CountDownTimeout {
+    expired_total: u32,
+    threshold: usize,
+    remaining: usize,
+}
+impl CountDownTimeout {
+    /// `CountDownTimeout` を生成する。
+    pub fn new(threshold: usize) -> Self {
+        Self {
+            expired_total: 0,
+            threshold,
+            remaining: threshold,
+        }
+    }
+
+    /// 連続して期限切れになった回数を返す。
+    ///
+    /// リセットされた場合は 0 に戻る。
+    pub fn expired_total(&self) -> u32 {
+        self.expired_total
+    }
+
+    /// 残り時間を 1 単位減少させ、0 になったら true を返す。
+    pub fn count_down(&mut self) -> bool {
+        self.remaining = self.remaining.saturating_sub(1);
+        if self.remaining == 0 {
+            self.expired_total += 1;
+            self.remaining = self.threshold;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// 残り時間を初期値に戻す。
+    pub fn reset(&mut self) {
+        self.expired_total = 0;
+        self.remaining = self.threshold;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_down_timeout_works() {
+        let mut timeout = CountDownTimeout::new(3);
+        assert!(!timeout.count_down());
+        assert!(!timeout.count_down());
+        assert!(timeout.count_down());
+        assert!(!timeout.count_down());
+        timeout.reset();
+        assert!(!timeout.count_down());
+        assert!(!timeout.count_down());
+        assert!(timeout.count_down());
+    }
+}


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

* 一定間隔(`log_leader_absence_threshold` * `node_polling_interval` ms)経過する毎にリーダーが不在になっていないかをチェックする。
* 不在であれば警告をログに出す。
* デフォルトではノイズになるためログを出さない。

### Purpose

#277 の状態が発生することを検知するために利用する。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.