### PR TITLE
[WIP] GetBucketStatistics returns the total storage usage of a bucket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,8 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cannyls"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.9.3"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -110,12 +109,11 @@ dependencies = [
 
 [[package]]
 name = "cannyls_rpc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.1"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
  "factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -193,7 +191,7 @@ dependencies = [
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "liberasurecode 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liberasurecode 1.0.3",
  "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -275,8 +273,8 @@ version = "0.16.1"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
+ "cannyls_rpc 0.1.1",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_http_server 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,7 +290,7 @@ dependencies = [
  "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.6.0",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -316,13 +314,13 @@ version = "0.8.0"
 dependencies = [
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frugalos_raft 0.9.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.6.0",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -350,7 +348,7 @@ dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -358,7 +356,7 @@ dependencies = [
  "frugalos_core 0.1.1",
  "frugalos_raft 0.9.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.6.0",
  "patricia_tree 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,7 +378,7 @@ dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_rpc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -402,8 +400,8 @@ version = "0.12.1"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls 0.9.3",
+ "cannyls_rpc 0.1.1",
  "ecpool 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +411,7 @@ dependencies = [
  "frugalos_mds 0.12.1",
  "frugalos_raft 0.9.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfrugalos 0.6.0",
  "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -571,7 +569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "liberasurecode"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -589,7 +586,6 @@ dependencies = [
 [[package]]
 name = "libfrugalos"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,8 +1306,6 @@ dependencies = [
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "599c561412645564bcfaaacf31368ddf074d7350097f1252565aa88680c9c3c2"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum cannyls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e57e3c054daa28d8447b1416f68760bbf9d6a07e4f083021a7d3e41e2f9c2c6"
-"checksum cannyls_rpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637a86ac6110573d654e67ffe7ff4a8f4f635c8c30c61ae1a5297333d601843b"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -1346,9 +1340,7 @@ dependencies = [
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum liberasurecode 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b9b4f294bb41a7f5333ab240eb33c71631378e32825d9db11f45e4ed0198325"
 "checksum libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
-"checksum libfrugalos 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef75bbd4ab341330829ff4664ae0f7d6355feda6e1809339a77e4b2dc839058d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,13 @@ trackable = "^0.2.21"
 
 [workspace]
 members = ["frugalos_core", "frugalos_config", "frugalos_mds", "frugalos_raft", "frugalos_segment"]
+
+[patch.crates-io]
+# feature/disk-usage
+cannyls = { path = "../cannyls" }
+# feature/disk-usage
+cannyls_rpc = { path = "../cannyls_rpc" }
+# feature/disk-usage
+liberasurecode = { path = "../liberasurecode" }
+# feature/segment-stats
+libfrugalos = { path = "../libfrugalos" }

--- a/frugalos_segment/src/client/dispersed_storage.rs
+++ b/frugalos_segment/src/client/dispersed_storage.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::needless_pass_by_value)]
 use cannyls::deadline::Deadline;
-use cannyls::lump::{LumpData, LumpHeader};
+use cannyls::lump::{LumpData, LumpHeader, LumpId};
+use cannyls::storage::StorageUsage;
 use cannyls_rpc::Client as CannyLsClient;
 use cannyls_rpc::DeviceId;
 use ecpool::liberasurecode::LibErasureCoderBuilder;
@@ -9,12 +10,13 @@ use fibers::time::timer;
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_core::tracer::SpanExt;
 use frugalos_raft::NodeId;
-use futures::{self, Async, Future, Poll};
+use futures::{self, Async, Future, Poll, Stream};
 use libfrugalos::entity::object::ObjectVersion;
 use rustracing::tag::{StdTag, Tag};
 use rustracing_jaeger::span::{Span, SpanHandle};
 use slog::Logger;
 use std::mem;
+use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 use trackable::error::ErrorKindExt;
@@ -63,6 +65,36 @@ impl DispersedClient {
             data_fragments,
             rpc_service,
         }
+    }
+    pub fn storage_usage(
+        self,
+        range: Range<LumpId>,
+        _parent: SpanHandle,
+    ) -> BoxFuture<Vec<StorageUsage>> {
+        let cannyls_config = self.client_config.cannyls.clone();
+        let rpc_service = self.rpc_service.clone();
+        let members = self.cluster.members.iter().cloned().collect::<Vec<_>>();
+        let future = futures::stream::iter_ok(members)
+            .and_then(move |member| {
+                let client = CannyLsClient::new(member.node.addr, rpc_service.clone());
+                let device_id = DeviceId::new(member.device);
+                let mut request = client.request();
+                request.rpc_options(cannyls_config.rpc_options());
+                Box::new(
+                    request
+                        .usage_range(device_id, range.clone())
+                        .then(|result| {
+                            // TODO メトリクス取得
+                            if let Err(_) = result {
+                                Ok(StorageUsage::Unknown)
+                            } else {
+                                result
+                            }
+                        }),
+                )
+            })
+            .collect();
+        Box::new(future.map_err(|e| track!(Error::from(e))))
     }
     pub fn get_fragment(
         self,

--- a/frugalos_segment/src/client/replicated_storage.rs
+++ b/frugalos_segment/src/client/replicated_storage.rs
@@ -1,11 +1,13 @@
 use cannyls::deadline::Deadline;
-use cannyls::lump::LumpData;
+use cannyls::lump::{LumpData, LumpId};
+use cannyls::storage::StorageUsage;
 use cannyls_rpc::Client as CannyLsClient;
 use cannyls_rpc::DeviceId;
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_raft::NodeId;
 use futures::{Async, Future, Poll};
 use libfrugalos::entity::object::ObjectVersion;
+use std::ops::Range;
 use std::sync::Arc;
 use trackable::error::ErrorKindExt;
 
@@ -40,6 +42,10 @@ impl ReplicatedClient {
             client_config,
             rpc_service,
         }
+    }
+    pub fn storage_usage(self, _range: Range<LumpId>) -> BoxFuture<Vec<StorageUsage>> {
+        // TODO implement
+        Box::new(futures::future::ok(Vec::new()))
     }
     pub fn get_fragment(
         self,

--- a/frugalos_segment/src/lib.rs
+++ b/frugalos_segment/src/lib.rs
@@ -31,6 +31,7 @@ extern crate siphasher;
 extern crate slog;
 #[macro_use]
 extern crate trackable;
+extern crate proc_macro;
 
 pub use client::ec::{build_ec, ErasureCoder};
 pub use client::Client;

--- a/src/http.rs
+++ b/src/http.rs
@@ -92,4 +92,7 @@ pub fn not_found() -> Error {
 pub struct BucketStatistics {
     /// バケツ内のオブジェクト数.
     pub objects: u64,
+
+    /// ストレージ使用量の近似値(バイト).
+    pub storage_usage_bytes: u64,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -216,21 +216,34 @@ impl HandleRequest for GetBucketStatistics {
         };
 
         let client = self.0.client.clone();
-        let future = futures::stream::iter_ok(0..segments)
+        let usage = futures::stream::iter_ok(0..segments.clone())
+            .and_then(move |segment| {
+                let request = client.request(bucket_id.clone());
+                request.segment_stats(segment).map_err(|e| track!(e))
+            })
+            .fold(0, |total, stats| -> Result<_> {
+                Ok(total + stats.storage_usage_bytes)
+            });
+        let bucket_id = get_bucket_id(req.url());
+        let client = self.0.client.clone();
+        let objects = futures::stream::iter_ok(0..segments)
             .and_then(move |segment| {
                 let request = client.request(bucket_id.clone());
                 request
                     .object_count(segment as usize)
                     .map_err(|e| track!(e))
             })
-            .fold(0, |total, objects| -> Result<_> { Ok(total + objects) })
-            .then(|result| match track!(result) {
-                Err(e) => Ok(make_json_response(Status::InternalServerError, Err(e))),
-                Ok(objects) => {
-                    let stats = BucketStatistics { objects };
-                    Ok(make_json_response(Status::Ok, Ok(stats)))
-                }
-            });
+            .fold(0, |total, objects| -> Result<_> { Ok(total + objects) });
+        let future = objects.join(usage).then(|result| match track!(result) {
+            Err(e) => Ok(make_json_response(Status::InternalServerError, Err(e))),
+            Ok((objects, usage_bytes)) => {
+                let stats = BucketStatistics {
+                    objects,
+                    storage_usage_bytes: usage_bytes,
+                };
+                Ok(make_json_response(Status::Ok, Ok(stats)))
+            }
+        });
         Box::new(future)
     }
 }


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

バケツ統計情報取得 API のレスポンスにバケツが使用しているストレージ容量を含まれるようになる。フォーマットは次のようになる。

```json
{
    ...,
    "storage_usage_bytes": 392293
}
```

ここで返ってくるストレージ使用量は cannyls の block size バイト単位で計算される概算値で正確な値ではない。

### Purpose

ストレージ使用量をある程度正確に取得できるようにすること。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.