### PR TITLE
segment_gc doesn't emit log when segment_node_handle.is_empty()

### DIFF
--- a/frugalos_segment/src/service.rs
+++ b/frugalos_segment/src/service.rs
@@ -277,7 +277,12 @@ where
         match manager.poll() {
             Ok(Async::NotReady) => (),
             Ok(Async::Ready(())) => {
-                info!(self.logger, "Segment gc done");
+                // segment node の個数が 0 の時、segment_gc の作成後すぐにここに到達する。
+                // そうなると SegmentService の poll の度にここに到達し、ログが大量に出てしまうことになる。
+                // これを回避するために、segment node の個数が 0 の時はログを出さないようにする。
+                if !self.segment_node_handles.is_empty() {
+                    info!(self.logger, "Segment gc done");
+                }
                 self.segment_gc_manager = None;
             }
             Err(e) => {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
セグメントノードの個数が 0 の場合、segment_gc 関係のログが出力されなくなる。

### Purpose
現状の frugalos では、セグメントノードの個数が 0 の場合に、segment_gc_manager が起動した後、即終了するという実装になっている。終了時にログが出るため、frugalos_segment::service::Service の poll の度に segment_gc_manager の終了ログが出力されることになる。これは煩わしいため、セグメントノードの個数が 0 の場合は終了ログを出さないようにする。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.