### PR TITLE
Fix storage_usage

### DIFF
--- a/frugalos_segment/src/client/mod.rs
+++ b/frugalos_segment/src/client/mod.rs
@@ -286,9 +286,10 @@ impl Client {
         parent: SpanHandle,
     ) -> impl Future<Item = SegmentStatistics, Error = Error> {
         let storage = self.storage.clone();
+        let is_metadata = self.storage.is_metadata();
         storage
             .storage_usage(parent)
-            .and_then(|usages| {
+            .and_then(move |usages| {
                 let f = |e: &StorageUsage| -> bool {
                     if let StorageUsage::Unknown = e {
                         true
@@ -296,7 +297,7 @@ impl Client {
                         false
                     }
                 };
-                if usages.iter().all(f) {
+                if !is_metadata && usages.iter().all(f) {
                     Err(ErrorKind::Invalid
                         .cause("All segment-nodes disk-usage unavailable")
                         .into())


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

GET `/v1/buckets/*/stats` のリクエストで metadata バケツのストレージ使用量を返すようになる (ただし全て使用量 0)

```
$ curl -s localhost:3000/v1/buckets/metadata_bucket/stats | python -m json.tool
{
    "objects": 1,
    "storage_usage_bytes_approximation_effectiveness": 0,
    "storage_usage_bytes_approximation_overall": 0,
    "storage_usage_bytes_approximation_redundance": 0,
    "storage_usage_bytes_real_effectiveness": 0,
    "storage_usage_bytes_real_overall": 0,
    "storage_usage_bytes_real_redundance": 0,
    "storage_usage_bytes_sum_effectiveness": 0,
    "storage_usage_bytes_sum_overall": 0,
    "storage_usage_bytes_sum_redundance": 0
}
```

replicated bucket の場合はエラーを返す

```
$ curl -s localhost:3000/v1/buckets/replicated_bucket/stats | python -m json.tool
{
    "cause": "All segment-nodes disk-usage unavailable",
    "history": [
        {
            "file": "src/client.rs",
            "line": 286,
            "message": "",
            "module_path": "frugalos::client"
        },
        {
            "file": "src/server.rs",
            "line": 241,
            "message": "",
            "module_path": "frugalos::server"
        },
        {
            "file": "src/server.rs",
            "line": 270,
            "message": "",
            "module_path": "frugalos::server"
        }
    ],
    "kind": "InvalidInput"
}
```

### Purpose

metadata bucket が #292 によって GET `/v1/bucket/*/stats` の応答が必ずエラーになってしまったため。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.