### PR TITLE
Fix clippy warnings (rustc-1.42)

### DIFF
--- a/frugalos_config/src/builder.rs
+++ b/frugalos_config/src/builder.rs
@@ -171,7 +171,7 @@ impl<'a> SegmentsBuilder<'a> {
         } else {
             // NOTE: gather経由の場合等にここに来ることがある
             // FIXME: この場合の割当方式を少し検討したいかも
-            *ring.calc_candidates(&key).nth(0).expect("Never fails").node
+            *ring.calc_candidates(&key).next().expect("Never fails").node
         }
     }
     fn select_gather_slot(&mut self, key: SlotKey, parent: &VirtualDevice) -> DeviceNo {

--- a/frugalos_config/src/service.rs
+++ b/frugalos_config/src/service.rs
@@ -425,9 +425,9 @@ impl Service {
 
         self.next_seqno = snapshot.next_seqno;
 
-        let old_buckets = mem::replace(&mut self.buckets, Default::default());
-        let old_devices = mem::replace(&mut self.devices, Default::default());
-        let old_servers = mem::replace(&mut self.servers, Default::default());
+        let old_buckets = mem::take(&mut self.buckets);
+        let old_devices = mem::take(&mut self.devices);
+        let old_servers = mem::take(&mut self.servers);
         self.buckets = snapshot
             .buckets
             .into_iter()

--- a/frugalos_raft/src/storage/log.rs
+++ b/frugalos_raft/src/storage/log.rs
@@ -118,7 +118,7 @@ impl Future for LoadLogInner {
                     return Ok(track!(f.poll())?.map(Log::Suffix));
                 }
                 LoadLogInner::CopyLogSuffix(ref mut f) => {
-                    let suffix = mem::replace(f, Default::default());
+                    let suffix = mem::take(f);
                     return Ok(Async::Ready(Log::Suffix(suffix)));
                 }
                 LoadLogInner::LoadLogPrefix {

--- a/frugalos_raft/src/storage/log_suffix.rs
+++ b/frugalos_raft/src/storage/log_suffix.rs
@@ -63,7 +63,7 @@ impl Future for LoadLogSuffix {
                 self.metrics
                     .load_log_suffix_duration_seconds
                     .observe(elapsed);
-                let suffix = mem::replace(&mut self.suffix, LogSuffix::default());
+                let suffix = mem::take(&mut self.suffix);
                 let _ = self.event_tx.send(Event::LogSuffixLoaded(suffix.clone()));
                 return Ok(Async::Ready(suffix));
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1070,7 +1070,7 @@ fn parse_etag_values(s: &str) -> Result<Vec<ObjectVersion>> {
     for token in s.split(',') {
         let token = token.trim();
         track_assert!(
-            token.bytes().nth(0) == Some(b'"') && token.bytes().last() == Some(b'"'),
+            token.bytes().next() == Some(b'"') && token.bytes().last() == Some(b'"'),
             ErrorKind::InvalidInput,
             "Malformed ETag value: {:?}",
             token


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

なし

### Purpose

stable が 1.42.0 に上がったことで clippy の警告が見られたため、修正

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.