### PR TITLE
Returns the segment number of an object

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -98,14 +98,14 @@ impl Bucket {
         Ok(())
     }
     pub fn get_segment(&self, id: &ObjectId) -> &Segment {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = siphasher::sip::SipHasher13::new();
-        id.hash(&mut hasher);
-        let i = hasher.finish() as usize % self.segments.len();
-        &self.segments[i]
+        &self.segments[self.segment_index(id)]
     }
     pub fn segments(&self) -> &[Segment] {
         &self.segments
+    }
+    /// 与えられた `ObjectId` が属すべきセグメント番号を返す。
+    pub fn segment_no(&self, id: &ObjectId) -> u16 {
+        self.segment_index(id) as u16
     }
 
     pub fn effectiveness_ratio(&self) -> f64 {
@@ -124,5 +124,13 @@ impl Bucket {
             frugalos_segment::config::Storage::Metadata => 0.0,
             _ => 1.0 - self.effectiveness_ratio(),
         }
+    }
+
+    /// 与えられた `ObjectId` が属すべきセグメントインデックスを返す。
+    fn segment_index(&self, id: &ObjectId) -> usize {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = siphasher::sip::SipHasher13::new();
+        id.hash(&mut hasher);
+        hasher.finish() as usize % self.segments.len()
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,6 +34,13 @@ impl FrugalosClient {
     pub(crate) fn new(buckets: Arc<AtomicImmut<HashMap<BucketId, Bucket>>>) -> Self {
         FrugalosClient { buckets }
     }
+    /// 与えられた `ObjectId` に対応するセグメント番号を返す。
+    pub fn segment_no(&self, bucket_id: &BucketId, object_id: &ObjectId) -> Option<u16> {
+        self.buckets
+            .load()
+            .get(bucket_id)
+            .map(|b| b.segment_no(object_id))
+    }
     pub fn request(&self, bucket_id: BucketId) -> Request {
         Request::new(self, bucket_id)
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -129,6 +129,13 @@ impl ObjectResponse {
             },
         }
     }
+    /// セグメント番号をレスポンスにセットする.
+    pub fn segment(mut self, segment_no: u16) -> Self {
+        self.inner.header_mut().add_field(unsafe {
+            HeaderField::new_unchecked("FrugalOS-Segment-Number", &format!("{}", segment_no))
+        });
+        self
+    }
     /// `ObjectVersion` をレスポンスにセットする.
     pub fn version(mut self, version: Option<ObjectVersion>) -> Self {
         if let Some(version) = version {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

`HEAD /v1/buckets/*/objects/*` の結果に `FrugalOS-Segment-Number` ヘッダーを付与し、オブジェクトが存在すべきセグメント番号を返すようになる。

存在しないバケツを指定した場合は 400 を返す。

存在するバケツを指定した場合は 404 を返すが、`FrugalOS-Segment-Number` がヘッダーに付与される。

```console
$ curl -I http://localhost:3100/v1/buckets/test/objects/hoge
HTTP/1.1 200 OK
Content-Type: application/octet-stream
FrugalOS-Segment-Number: 2
ETag: "1"
Content-Length: 0

$ curl -I http://localhost:3100/v1/buckets/test/objects/foo
HTTP/1.1 404 Not Found
Content-Type: application/json
FrugalOS-Segment-Number: 4
Transfer-Encoding: chunked
```

### Purpose

This resolves #253.

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.