### PR TITLE
Fixes the incorrect log at ObjectHead

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -502,7 +502,7 @@ impl HandleRequest for HeadObject {
                 Err(e) => {
                     warn!(
                         logger,
-                        "Cannot get object (bucket={:?}, object={:?}): {}",
+                        "Cannot head object (bucket={:?}, object={:?}): {}",
                         get_bucket_id(req.url()),
                         get_object_id(req.url()),
                         e


### PR DESCRIPTION
https://github.com/frugalos/frugalos/issues/274

## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

ログメッセージが `Cannot head object` に変わる。

動作確認方法

```console
$ curl http://localhost:3100/v1/buckets/test/objects/hoge -X PUT -d 'a'
$ curl http://localhost:3100/v1/buckets/test/objects/hoge/fragments/0 -X DELETE
$ curl http://localhost:3100/v1/buckets/test/objects/hoge/fragments/1 -X DELETE
$ curl -I 'http://localhost:3100/v1/buckets/test/objects/hoge?check_storage=true'
```

### Purpose

This resolves #274

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.