### PR TITLE
Add device verification when put-bucket / put-device

### DIFF
--- a/frugalos_config/src/device_tree.rs
+++ b/frugalos_config/src/device_tree.rs
@@ -46,7 +46,7 @@ pub fn verify_device_tree_dfs(
     if device.is_none() {
         let e =
             ErrorKind::InvalidInput.cause(format!("Referred device:{} does not exist.", device_id));
-        return Err(Error::from(e));
+        return track!(Err(Error::from(e)));
     }
     let device = device.expect("Never fail");
     if let Device::Virtual(v) = device {
@@ -54,9 +54,9 @@ pub fn verify_device_tree_dfs(
             if visit.get(child_device_id).is_none() {
                 verify_device_tree_dfs(visit, child_device_id, devices)?
             } else {
-                let e = ErrorKind::InvalidInput
-                    .cause("TODO: Illegal device construct detected.".to_owned());
-                return Err(Error::from(e));
+                let e =
+                    ErrorKind::InvalidInput.cause("Illegal device construct detected.".to_owned());
+                return track!(Err(Error::from(e)));
             }
         }
     }
@@ -103,7 +103,7 @@ mod tests {
         //   - file0
         //   - file1
         //   - file2
-        //   - file3 ( not regiesterd )
+        //   - file3 ( not registered )
 
         let file0_id = "file0".to_owned();
         let file0 = create_file_device(file0_id.clone());

--- a/frugalos_config/src/device_tree.rs
+++ b/frugalos_config/src/device_tree.rs
@@ -1,0 +1,237 @@
+//! デバイスで構成されるグラフ構造に関する補助関数を定義する
+//!
+//! - 任意のデバイスを根とする部分グラフ構造は木でなければならない
+//!   - 全デバイスからなるグラフは木である必要はない
+
+use libfrugalos::entity::device::{Device, DeviceId, DeviceKind};
+use std::collections::{BTreeMap, HashSet};
+use trackable::error::ErrorKindExt;
+
+use {Error, ErrorKind, Result};
+
+/// 新しく追加されるデバイスの検証を行う
+pub fn verify_new_device(device: &Device, devices: &BTreeMap<DeviceId, Device>) -> Result<()> {
+    if let DeviceKind::Virtual = device.kind() {
+        let mut new_devices = devices.clone();
+        new_devices.insert(device.id().to_owned(), device.clone());
+        verify_device_tree(device.id(), &new_devices)
+    } else {
+        Ok(())
+    }
+}
+
+/// 引数デバイスを根としたデバイスツリーの検証を行う
+#[allow(clippy::ptr_arg)]
+pub fn verify_device_tree(
+    device_id: &DeviceId,
+    devices: &BTreeMap<DeviceId, Device>,
+) -> Result<()> {
+    let mut visit = HashSet::new();
+    verify_device_tree_dfs(&mut visit, device_id, devices)
+}
+
+/// デバイスツリーの検証を行う
+///
+/// いずれかの条件を満たす時デバイスツリーに問題があるとみなす
+/// - 木でない
+/// - 存在しないデバイスを参照している
+#[allow(clippy::ptr_arg)]
+pub fn verify_device_tree_dfs(
+    visit: &mut HashSet<DeviceId>,
+    device_id: &DeviceId,
+    devices: &BTreeMap<DeviceId, Device>,
+) -> Result<()> {
+    visit.insert(device_id.to_owned());
+    let device = devices.get(device_id);
+    if device.is_none() {
+        let e =
+            ErrorKind::InvalidInput.cause(format!("Referred device:{} does not exist.", device_id));
+        return Err(Error::from(e));
+    }
+    let device = device.expect("Never fail");
+    if let Device::Virtual(v) = device {
+        for child_device_id in v.children.iter() {
+            if visit.get(child_device_id).is_none() {
+                verify_device_tree_dfs(visit, child_device_id, devices)?
+            } else {
+                let e = ErrorKind::InvalidInput
+                    .cause("TODO: Illegal device construct detected.".to_owned());
+                return Err(Error::from(e));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Result;
+    use device_tree::{verify_device_tree, verify_new_device};
+    use libfrugalos::entity::device::{
+        Device, DeviceId, FileDevice, SegmentAllocationPolicy, VirtualDevice, Weight,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::path::PathBuf;
+    use test_util::build_device_tree;
+
+    fn create_file_device(id: DeviceId) -> Device {
+        Device::File(FileDevice {
+            id,
+            seqno: 0,
+            weight: Weight::Auto,
+            server: String::from("frugalos-server"),
+            capacity: 0,
+            filepath: PathBuf::new(),
+        })
+    }
+
+    fn create_virtual_device(id: DeviceId, children: BTreeSet<DeviceId>) -> Device {
+        Device::Virtual(VirtualDevice {
+            id,
+            seqno: 0,
+            weight: Weight::Auto,
+            children,
+            policy: SegmentAllocationPolicy::ScatterIfPossible,
+        })
+    }
+
+    fn create_device_btree_map_1(root_id: DeviceId) -> BTreeMap<DeviceId, Device> {
+        // generate device tree (include illegal device)
+        //
+        // root
+        // - sub_root
+        //   - file0
+        //   - file1
+        //   - file2
+        //   - file3 ( not regiesterd )
+
+        let file0_id = "file0".to_owned();
+        let file0 = create_file_device(file0_id.clone());
+        let file1_id = "file1".to_owned();
+        let file1 = create_file_device(file1_id.clone());
+        let file2_id = "file2".to_owned();
+        let file2 = create_file_device(file2_id.clone());
+
+        let sub_root_id = "sub_root".to_owned();
+        let mut sub_root_children = BTreeSet::new();
+        sub_root_children.insert(file0_id.clone());
+        sub_root_children.insert(file1_id.clone());
+        sub_root_children.insert(file2_id.clone());
+        sub_root_children.insert("file3".to_owned());
+        let sub_root = create_virtual_device(sub_root_id.clone(), sub_root_children);
+
+        let mut root_children = BTreeSet::new();
+        root_children.insert(sub_root_id.clone());
+        let root = create_virtual_device(root_id.clone(), root_children);
+
+        let entries = vec![
+            (file0, file0_id),
+            (file1, file1_id),
+            (file2, file2_id),
+            (sub_root, sub_root_id),
+            (root, root_id),
+        ];
+        let mut btree_map = BTreeMap::new();
+        for (v, k) in entries.into_iter() {
+            btree_map.insert(k, v);
+        }
+        btree_map
+    }
+
+    fn create_device_btree_map_2() -> BTreeMap<DeviceId, Device> {
+        // generate device tree (cycle)
+        //  - virtual1
+        //    - virtual2
+        //       - virtual0
+        //          - virtual1
+
+        let virtual0_id = "virtual0".to_owned();
+        let virtual1_id = "virtual1".to_owned();
+        let virtual2_id = "virtual2".to_owned();
+
+        let mut children = BTreeSet::new();
+        children.insert(virtual2_id.clone());
+        let virtual1 = create_virtual_device(virtual1_id.clone(), children);
+
+        let mut children = BTreeSet::new();
+        children.insert(virtual0_id.clone());
+        let virtual2 = create_virtual_device(virtual2_id.clone(), children);
+
+        let mut children = BTreeSet::new();
+        children.insert(virtual1_id.clone());
+        let virtual0 = create_virtual_device(virtual0_id.clone(), children);
+
+        let entries = vec![
+            (virtual0, virtual0_id),
+            (virtual1, virtual1_id),
+            (virtual2, virtual2_id),
+        ];
+        let mut btree_map = BTreeMap::new();
+        for (v, k) in entries.into_iter() {
+            btree_map.insert(k, v);
+        }
+        btree_map
+    }
+
+    fn create_device_btree_map_3() -> (BTreeMap<DeviceId, Device>, Device) {
+        // generate device tree (not tree)
+        // virtual0
+        //   - virtual1
+        //     - file1
+        //   - virtual2
+        //     - file1
+        let virtual0_id = "virtual0".to_owned();
+        let virtual1_id = "virtual1".to_owned();
+        let virtual2_id = "virtual2".to_owned();
+        let file1_id = "file1".to_owned();
+
+        let file1 = create_file_device(file1_id.clone());
+
+        let mut children = BTreeSet::new();
+        children.insert(file1_id.clone());
+        let virtual1 = create_virtual_device(virtual1_id.clone(), children.clone());
+        let virtual2 = create_virtual_device(virtual2_id.clone(), children);
+
+        let mut children = BTreeSet::new();
+        children.insert(virtual1_id.clone());
+        children.insert(virtual2_id.clone());
+        let virtual0 = create_virtual_device(virtual0_id, children);
+
+        let entries = vec![
+            (file1, file1_id),
+            (virtual1, virtual1_id),
+            (virtual2, virtual2_id),
+        ];
+
+        let mut btree_map = BTreeMap::new();
+        for (v, k) in entries.into_iter() {
+            btree_map.insert(k, v);
+        }
+        (btree_map, virtual0)
+    }
+
+    #[test]
+    fn verify_device_works() -> Result<()> {
+        let (devices, root_device_id) =
+            build_device_tree(&[3, 8, 1, 2], SegmentAllocationPolicy::ScatterIfPossible);
+        let result = verify_device_tree(&root_device_id, &devices);
+        assert!(result.is_ok());
+
+        // reference illegal device
+        let devices = create_device_btree_map_1(root_device_id.clone());
+        let result = verify_device_tree(&root_device_id, &devices);
+        assert!(result.is_err());
+
+        // cycle graph
+        let devices = create_device_btree_map_2();
+        let result = verify_device_tree(&"virtual1".to_owned(), &devices);
+        assert!(result.is_err());
+
+        // not tree
+        let (devices, new_device) = create_device_btree_map_3();
+        let result = verify_new_device(&new_device, &devices);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/frugalos_config/src/lib.rs
+++ b/frugalos_config/src/lib.rs
@@ -41,6 +41,7 @@ pub mod cluster;
 
 mod builder;
 mod config;
+mod device_tree;
 mod error;
 mod machine;
 mod protobuf;

--- a/frugalos_config/src/service.rs
+++ b/frugalos_config/src/service.rs
@@ -7,12 +7,12 @@ use fibers_rpc::server::ServerBuilder as RpcServerBuilder;
 use frugalos_raft::{self, RaftIo};
 use futures::{Async, Future, Poll, Stream};
 use libfrugalos::entity::bucket::{Bucket, BucketId, BucketSummary};
-use libfrugalos::entity::device::{Device, DeviceId, DeviceKind, DeviceSummary};
+use libfrugalos::entity::device::{Device, DeviceId, DeviceSummary};
 use libfrugalos::entity::server::{Server, ServerId, ServerSummary};
 use raftlog::log::{LogEntry, LogIndex, ProposalId};
 use raftlog::{self, ReplicatedLog};
 use slog::Logger;
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::mem;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -22,6 +22,7 @@ use builder::SegmentTableBuilder;
 use cluster;
 use config;
 use config::server_to_frugalos_raft_node;
+use device_tree;
 use machine::{Command, DeviceGroup, NextSeqNo, SegmentTable, Snapshot};
 use protobuf;
 use rpc;
@@ -594,7 +595,7 @@ impl Service {
             }
             Request::GetDevice { id, reply } => reply.exit(Ok(self.devices.get(&id).cloned())),
             Request::PutDevice { device, reply } => {
-                if let Err(e) = verify_new_device(&device, &self.devices) {
+                if let Err(e) = device_tree::verify_new_device(&device, &self.devices) {
                     reply.exit(Err(e));
                     return Ok(());
                 }
@@ -622,7 +623,7 @@ impl Service {
             }
             Request::GetBucket { id, reply } => reply.exit(Ok(self.buckets.get(&id).cloned())),
             Request::PutBucket { bucket, reply } => {
-                if let Err(e) = verify_device_tree(bucket.device(), &self.devices) {
+                if let Err(e) = device_tree::verify_device_tree(bucket.device(), &self.devices) {
                     reply.exit(Err(e));
                     return Ok(());
                 }
@@ -1064,235 +1065,5 @@ impl ServiceHandle {
         let request = Request::DeleteBucket { id, reply };
         let _ = self.request_tx.send(request);
         response
-    }
-}
-
-/// 新しく追加されるデバイスの検証を行う
-pub(crate) fn verify_new_device(
-    device: &Device,
-    devices: &BTreeMap<DeviceId, Device>,
-) -> Result<()> {
-    if let DeviceKind::Virtual = device.kind() {
-        let mut new_devices = devices.clone();
-        new_devices.insert(device.id().to_owned(), device.clone());
-        verify_device_tree(device.id(), &new_devices)
-    } else {
-        Ok(())
-    }
-}
-
-/// 引数デバイスを根としたデバイスツリーの検証を行う
-#[allow(clippy::ptr_arg)]
-pub(crate) fn verify_device_tree(
-    device_id: &DeviceId,
-    devices: &BTreeMap<DeviceId, Device>,
-) -> Result<()> {
-    let mut visit = HashSet::new();
-    verify_device_tree_dfs(&mut visit, device_id, devices)
-}
-
-/// デバイスツリーの検証を行う
-///
-/// いずれかの条件を満たす時デバイスツリーに問題があるとみなす
-/// - 木でない
-/// - 存在しないデバイスを参照している
-#[allow(clippy::ptr_arg)]
-pub(crate) fn verify_device_tree_dfs(
-    visit: &mut HashSet<DeviceId>,
-    device_id: &DeviceId,
-    devices: &BTreeMap<DeviceId, Device>,
-) -> Result<()> {
-    visit.insert(device_id.to_owned());
-    let device = devices.get(device_id);
-    if device.is_none() {
-        let e =
-            ErrorKind::InvalidInput.cause(format!("Referred device:{} does not exist.", device_id));
-        return Err(Error::from(e));
-    }
-    let device = device.expect("Never fail");
-    if let Device::Virtual(v) = device {
-        for child_device_id in v.children.iter() {
-            if visit.get(child_device_id).is_none() {
-                verify_device_tree_dfs(visit, child_device_id, devices)?
-            } else {
-                let e = ErrorKind::InvalidInput
-                    .cause("TODO: Illegal device construct detected.".to_owned());
-                return Err(Error::from(e));
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Result;
-    use libfrugalos::entity::device::{
-        Device, DeviceId, FileDevice, SegmentAllocationPolicy, VirtualDevice, Weight,
-    };
-    use service::{verify_device_tree, verify_new_device};
-    use std::collections::{BTreeMap, BTreeSet};
-    use std::path::PathBuf;
-    use test_util::build_device_tree;
-
-    fn create_file_device(id: DeviceId) -> Device {
-        Device::File(FileDevice {
-            id,
-            seqno: 0,
-            weight: Weight::Auto,
-            server: String::from("frugalos-server"),
-            capacity: 0,
-            filepath: PathBuf::new(),
-        })
-    }
-
-    fn create_virtual_device(id: DeviceId, children: BTreeSet<DeviceId>) -> Device {
-        Device::Virtual(VirtualDevice {
-            id,
-            seqno: 0,
-            weight: Weight::Auto,
-            children,
-            policy: SegmentAllocationPolicy::ScatterIfPossible,
-        })
-    }
-
-    fn create_device_btree_map_1(root_id: DeviceId) -> BTreeMap<DeviceId, Device> {
-        // generate device tree (include illegal device)
-        //
-        // root
-        // - sub_root
-        //   - file0
-        //   - file1
-        //   - file2
-        //   - file3 ( not regiesterd )
-
-        let file0_id = "file0".to_owned();
-        let file0 = create_file_device(file0_id.clone());
-        let file1_id = "file1".to_owned();
-        let file1 = create_file_device(file1_id.clone());
-        let file2_id = "file2".to_owned();
-        let file2 = create_file_device(file2_id.clone());
-
-        let sub_root_id = "sub_root".to_owned();
-        let mut sub_root_children = BTreeSet::new();
-        sub_root_children.insert(file0_id.clone());
-        sub_root_children.insert(file1_id.clone());
-        sub_root_children.insert(file2_id.clone());
-        sub_root_children.insert("file3".to_owned());
-        let sub_root = create_virtual_device(sub_root_id.clone(), sub_root_children);
-
-        let mut root_children = BTreeSet::new();
-        root_children.insert(sub_root_id.clone());
-        let root = create_virtual_device(root_id.clone(), root_children);
-
-        let entries = vec![
-            (file0, file0_id),
-            (file1, file1_id),
-            (file2, file2_id),
-            (sub_root, sub_root_id),
-            (root, root_id),
-        ];
-        let mut btree_map = BTreeMap::new();
-        for (v, k) in entries.into_iter() {
-            btree_map.insert(k, v);
-        }
-        btree_map
-    }
-
-    fn create_device_btree_map_2() -> BTreeMap<DeviceId, Device> {
-        // generate device tree (cycle)
-        //  - virtual1
-        //    - virtual2
-        //       - virtual0
-        //          - virtual1
-
-        let virtual0_id = "virtual0".to_owned();
-        let virtual1_id = "virtual1".to_owned();
-        let virtual2_id = "virtual2".to_owned();
-
-        let mut children = BTreeSet::new();
-        children.insert(virtual2_id.clone());
-        let virtual1 = create_virtual_device(virtual1_id.clone(), children);
-
-        let mut children = BTreeSet::new();
-        children.insert(virtual0_id.clone());
-        let virtual2 = create_virtual_device(virtual2_id.clone(), children);
-
-        let mut children = BTreeSet::new();
-        children.insert(virtual1_id.clone());
-        let virtual0 = create_virtual_device(virtual0_id.clone(), children);
-
-        let entries = vec![
-            (virtual0, virtual0_id),
-            (virtual1, virtual1_id),
-            (virtual2, virtual2_id),
-        ];
-        let mut btree_map = BTreeMap::new();
-        for (v, k) in entries.into_iter() {
-            btree_map.insert(k, v);
-        }
-        btree_map
-    }
-
-    fn create_device_btree_map_3() -> (BTreeMap<DeviceId, Device>, Device) {
-        // generate device tree (not tree)
-        // virtual0
-        //   - virtual1
-        //     - file1
-        //   - virtual2
-        //     - file1
-        let virtual0_id = "virtual0".to_owned();
-        let virtual1_id = "virtual1".to_owned();
-        let virtual2_id = "virtual2".to_owned();
-        let file1_id = "file1".to_owned();
-
-        let file1 = create_file_device(file1_id.clone());
-
-        let mut children = BTreeSet::new();
-        children.insert(file1_id.clone());
-        let virtual1 = create_virtual_device(virtual1_id.clone(), children.clone());
-        let virtual2 = create_virtual_device(virtual2_id.clone(), children);
-
-        let mut children = BTreeSet::new();
-        children.insert(virtual1_id.clone());
-        children.insert(virtual2_id.clone());
-        let virtual0 = create_virtual_device(virtual0_id, children);
-
-        let entries = vec![
-            (file1, file1_id),
-            (virtual1, virtual1_id),
-            (virtual2, virtual2_id),
-        ];
-
-        let mut btree_map = BTreeMap::new();
-        for (v, k) in entries.into_iter() {
-            btree_map.insert(k, v);
-        }
-        (btree_map, virtual0)
-    }
-
-    #[test]
-    fn verify_device_works() -> Result<()> {
-        let (devices, root_device_id) =
-            build_device_tree(&[3, 8, 1, 2], SegmentAllocationPolicy::ScatterIfPossible);
-        let result = verify_device_tree(&root_device_id, &devices);
-        assert!(result.is_ok());
-
-        // reference illegal device
-        let devices = create_device_btree_map_1(root_device_id.clone());
-        let result = verify_device_tree(&root_device_id, &devices);
-        assert!(result.is_err());
-
-        // cycle graph
-        let devices = create_device_btree_map_2();
-        let result = verify_device_tree(&"virtual1".to_owned(), &devices);
-        assert!(result.is_err());
-
-        // not tree
-        let (devices, new_device) = create_device_btree_map_3();
-        let result = verify_new_device(&new_device, &devices);
-        assert!(result.is_err());
-
-        Ok(())
     }
 }

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -159,7 +159,13 @@ impl HandleRequest for PutDevice {
         let device = req.into_body();
         let future = self.0.client().put_device(device).then(|result| {
             let (status, body) = match track!(result) {
-                Err(e) => (Status::InternalServerError, Err(Error::from(e))),
+                Err(e) => {
+                    if let libfrugalos::ErrorKind::InvalidInput = e.kind() {
+                        (Status::BadRequest, Err(Error::from(e)))
+                    } else {
+                        (Status::InternalServerError, Err(Error::from(e)))
+                    }
+                }
                 Ok(v) => (Status::Ok, Ok(v)),
             };
             Ok(make_json_response(status, body))


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

PutBucket / PutDevice 時に関連デバイスによるツリー構造の検証を追加。検証では未登録デバイスが参照されていないこと、関連デバイス群が木構造であることを確認する。

### Behavior

- バケツが参照するデバイスツリーに問題がある場合は PutBucket に失敗する
- 新たに追加しようとするデバイスを根とするデバイスツリーに問題がある場合は PutDevice に失敗する

### Purpose

#96 

## How to test this PR

```console
// put bucket
// specify non-registered device 
$ curl -s -D - -X PUT -d '{"dispersed":{"id":"hoge","device":"blah_device","tolerable_faults":1,"data_fragment_count":2}}' localhost:3000/v1/buckets/hoge
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked

{"kind":"InvalidInput","cause":"InvalidInput (cause; InvalidInput (cause; Referred device:blah_device does not exist.)\nHISTORY:\n  [0] at frugalos_config/src/service.rs:951\n)\nHISTORY:\n  [0] at /home/tmiyashita/.cargo/registry/src/github.com-1ecc6299db9ec823/libfrugalos-0.6.1/src/client/mod.rs:30\n  [1] at /home/tmiyashita/.cargo/registry/src/github.com-1ecc6299db9ec823/libfrugalos-0.6.1/src/client/config.rs:165 -- frugalos.config.bucket.put\n  [2] at src/config_server.rs:233\n","history":[]}%

// put device
// specify non-registered device to children
$ curl -D - -s -X PUT -d '{"virtual":{"id":"new_device","children":["not_registerd_device"]}}' localhost:3000/v1/devices/new_device
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked

{"kind":"InvalidInput","cause":"InvalidInput (cause; InvalidInput (cause; Referred device:not_registerd_device does not exist.)\nHISTORY:\n  [0] at frugalos_config/src/service.rs:955\n)\nHISTORY:\n  [0] at /home/tmiyashita/.cargo/registry/src/github.com-1ecc6299db9ec823/libfrugalos-0.6.1/src/client/mod.rs:30\n  [1] at /home/tmiyashita/.cargo/registry/src/github.com-1ecc6299db9ec823/libfrugalos-0.6.1/src/client/config.rs:165 -- frugalos.config.device.put\n  [2] at src/config_server.rs:161\n","history":[]}%

```

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
