### PR TITLE
Add frugalos object-requests metrics

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -3,7 +3,7 @@ use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
 use frugalos_segment::config::ClusterMember;
 use frugalos_segment::Client as Segment;
 use frugalos_segment::{self, ErasureCoder, FrugalosSegmentConfig};
-use libfrugalos::entity::bucket::Bucket as BucketConfig;
+use libfrugalos::entity::bucket::{Bucket as BucketConfig, BucketKind};
 use libfrugalos::entity::object::ObjectId;
 use siphasher;
 use slog::Logger;
@@ -123,6 +123,13 @@ impl Bucket {
         match self.storage_config {
             frugalos_segment::config::Storage::Metadata => 0.0,
             _ => 1.0 - self.effectiveness_ratio(),
+        }
+    }
+    pub fn kind(&self) -> BucketKind {
+        match self.storage_config {
+            frugalos_segment::config::Storage::Metadata => BucketKind::Metadata,
+            frugalos_segment::config::Storage::Replicated(_) => BucketKind::Replicated,
+            frugalos_segment::config::Storage::Dispersed(_) => BucketKind::Dispersed,
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use cannyls_rpc::DeviceId;
 use frugalos_segment::{ObjectValue, SegmentStatistics};
 use futures::{self, Future};
 use libfrugalos::consistency::ReadConsistency;
-use libfrugalos::entity::bucket::BucketId;
+use libfrugalos::entity::bucket::{BucketId, BucketKind};
 use libfrugalos::entity::object::{
     DeleteObjectsByPrefixSummary, FragmentsSummary, ObjectId, ObjectPrefix, ObjectSummary,
     ObjectVersion,
@@ -54,6 +54,9 @@ impl FrugalosClient {
             .load()
             .get(bucket_id)
             .map(|b| b.redundance_ratio())
+    }
+    pub fn bucket_kind(&self, bucket_id: &BucketId) -> Option<BucketKind> {
+        self.buckets.load().get(bucket_id).map(|b| b.kind())
     }
 }
 impl fmt::Debug for FrugalosClient {

--- a/src/server.rs
+++ b/src/server.rs
@@ -77,7 +77,7 @@ macro_rules! try_badarg_option {
 ///
 /// bucket_kind 毎に label を設定する
 #[derive(Clone)]
-pub(crate) struct ObjectRequestMetrics {
+struct ObjectRequestMetrics {
     get_total: Counter,
     put_total: Counter,
     delete_total: Counter,
@@ -125,7 +125,7 @@ impl ObjectRequestMetrics {
 }
 
 #[derive(Clone)]
-pub(crate) struct Metrics {
+struct Metrics {
     object_requests: HashMap<u32, ObjectRequestMetrics>,
 }
 impl Metrics {

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,22 +84,28 @@ pub(crate) struct ObjectRequestMetrics {
 }
 impl ObjectRequestMetrics {
     pub fn new(bucket_kind: &str) -> Self {
-        let get_total = CounterBuilder::new("get_total")
-            .namespace("frugalos_object_request_http")
+        let get_total = CounterBuilder::new("object_requests_total")
+            .namespace("frugalos")
+            .subsystem("http")
             .label("bucket_kind", bucket_kind)
+            .label("method", "GET")
             .default_registry()
             .finish()
             .expect("metric should be well-formed");
-        let put_total = CounterBuilder::new("put_total")
-            .namespace("frugalos_object_request_http")
-            .default_registry()
+        let put_total = CounterBuilder::new("object_requests_total")
+            .namespace("frugalos")
+            .subsystem("http")
             .label("bucket_kind", bucket_kind)
+            .label("method", "PUT")
+            .default_registry()
             .finish()
             .expect("metric should be well-formed");
-        let delete_total = CounterBuilder::new("delete_total")
-            .namespace("frugalos_object_request_http")
-            .default_registry()
+        let delete_total = CounterBuilder::new("object_requests_total")
+            .namespace("frugalos")
+            .subsystem("http")
             .label("bucket_kind", bucket_kind)
+            .label("method", "DELETE")
+            .default_registry()
             .finish()
             .expect("metric should be well-formed");
         ObjectRequestMetrics {


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

HTTP リクエストによるオブジェクト操作 ( GET / PUT / DELETE ) に対するメトリクス (Counter) を追加. 

`rate(frugalos_object_request_http_get_total[3m])` などでの利用を想定

### Purpose

既に似たメトリクスとして, `fibers_http_server_handler_requests_total` が存在するが, 異なる点として label に bucket_kind を設定し, bucket_kind 毎 ( dispersed /replicated / metadata ) の数値を計測する. 

## How to test this PR

実際にいくつかオブジェクト操作を試してから metrics を確認する. 操作は成功/失敗を問わず, オブジェクトに関連する操作であればなんでもよい.

```console
# TYPE frugalos_http_object_requests_total counter
frugalos_http_object_requests_total{bucket_kind="dispersed",method="DELETE"} 1
frugalos_http_object_requests_total{bucket_kind="dispersed",method="GET"} 1
frugalos_http_object_requests_total{bucket_kind="dispersed",method="PUT"} 1
frugalos_http_object_requests_total{bucket_kind="metadata",method="DELETE"} 1
frugalos_http_object_requests_total{bucket_kind="metadata",method="GET"} 2
frugalos_http_object_requests_total{bucket_kind="metadata",method="PUT"} 1
frugalos_http_object_requests_total{bucket_kind="replicated",method="DELETE"} 1
frugalos_http_object_requests_total{bucket_kind="replicated",method="GET"} 1
frugalos_http_object_requests_total{bucket_kind="replicated",method="PUT"} 1
```


## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
