### PR TITLE
デバイスを落とせるようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "cannyls_rpc"
 version = "0.3.0"
-source = "git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device#9c9e4ccf7775c7dfc198133e3da073f825c6e8f9"
+source = "git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device#a401224afa6f647535cc5bb76ef3bc9f737e885c"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,1438 +4,1436 @@
 name = "adler32"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 
 [[package]]
 name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 dependencies = [
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "atomic_immut"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9fcea66a65a49890058406499cca8906e4e9cd1173bfeb272dcd2ac603e4fa"
 
 [[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "termion",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "backtrace"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 dependencies = [
- "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "backtrace-sys"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "bincode"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "serde",
 ]
 
 [[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 
 [[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "bytecodec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599c561412645564bcfaaacf31368ddf074d7350097f1252565aa88680c9c3c2"
 dependencies = [
- "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode",
+ "byteorder",
+ "serde",
+ "serde_json",
+ "trackable",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 
 [[package]]
 name = "cannyls"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc3889f5a278d46b34e1fb0e6d6619ffc18d84811aedeb50e210dcc96bd3328"
 dependencies = [
- "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32",
+ "byteorder",
+ "fibers",
+ "futures",
+ "libc",
+ "prometrics",
+ "slog",
+ "trackable",
+ "uuid",
 ]
 
 [[package]]
 name = "cannyls_rpc"
-version = "0.3.0"
-source = "git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device#a401224afa6f647535cc5bb76ef3bc9f737e885c"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3593e08c69a370ce2fb89345a0e0714b7dc2ad5991572d3b9a17623fae2d63b8"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "bytecodec",
+ "cannyls",
+ "factory",
+ "fibers",
+ "fibers_rpc",
+ "futures",
+ "protobuf_codec",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "cc"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 
 [[package]]
 name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-traits",
+ "time",
 ]
 
 [[package]]
 name = "clap"
 version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
 ]
 
 [[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 dependencies = [
- "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "build_const",
 ]
 
 [[package]]
 name = "crossbeam"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 
 [[package]]
 name = "dtoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 
 [[package]]
 name = "ecpool"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b26a3d6098ac6bf3952357c8dbe386705408069942b35f6c9da5dac5233849"
 dependencies = [
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "liberasurecode 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fibers",
+ "fibers_tasque",
+ "futures",
+ "liberasurecode",
+ "trackable",
 ]
 
 [[package]]
 name = "factory"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12035ccde1cff7c507200fd9e7ad0dbceda81d3cf6f68a265974a213d24acfde"
 
 [[package]]
 name = "fibers"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce97d737d7eda3d2e8a907892b4c4fdd3857cb6f18b58047645011c5a0b46e7"
 dependencies = [
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "nbchan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "splay_tree 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "mio",
+ "nbchan",
+ "num_cpus",
+ "splay_tree",
 ]
 
 [[package]]
 name = "fibers_global"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342af6a6f5bcb2fbd6a08178d7e1816af40ec94d38071eb8abd1ab60b0d44d2b"
 dependencies = [
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fibers",
+ "futures",
+ "lazy_static 1.1.0",
 ]
 
 [[package]]
 name = "fibers_http_server"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b2f7e9a07ed9e13092fec835e85b7d9c7345ec88263c67b42e046cd930f777"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "bytecodec",
+ "factory",
+ "fibers",
+ "futures",
+ "httpcodec",
+ "prometrics",
+ "slog",
+ "trackable",
+ "url",
 ]
 
 [[package]]
 name = "fibers_rpc"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56413f3c95f2a93aaf579d1f549ac4043b8a2ed5f37e7fd5d3d32be58ef88691"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "bytecodec",
+ "byteorder",
+ "factory",
+ "fibers",
+ "fibers_tasque",
+ "futures",
+ "prometrics",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "fibers_tasque"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec69910a085e2be9327da6c3c82556b180e8be6d91bc4e0d18b49b4b0fbf32f9"
 dependencies = [
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tasque 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fibers",
+ "futures",
+ "lazy_static 1.1.0",
+ "tasque",
 ]
 
 [[package]]
 name = "frugalos"
 version = "1.1.2"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)",
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_http_server 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frugalos_config 1.1.2",
- "frugalos_core 1.0.0",
- "frugalos_mds 1.1.2",
- "frugalos_raft 1.1.2",
- "frugalos_segment 1.1.2",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sloggers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "bytecodec",
+ "byteorder",
+ "cannyls",
+ "cannyls_rpc",
+ "clap",
+ "fibers",
+ "fibers_http_server",
+ "fibers_rpc",
+ "fibers_tasque",
+ "frugalos_config",
+ "frugalos_core",
+ "frugalos_mds",
+ "frugalos_raft",
+ "frugalos_segment",
+ "futures",
+ "hostname",
+ "httpcodec",
+ "jemalloc-ctl",
+ "jemallocator",
+ "libfrugalos",
+ "num_cpus",
+ "prometrics",
+ "raftlog",
+ "rustracing",
+ "rustracing_jaeger",
+ "serde",
+ "serde_derive",
+ "serde_ignored",
+ "serde_yaml",
+ "siphasher",
+ "slog",
+ "sloggers",
+ "tempdir",
+ "trackable",
+ "url",
 ]
 
 [[package]]
 name = "frugalos_config"
 version = "1.1.2"
 dependencies = [
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frugalos_raft 1.1.2",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rendezvous_hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecodec",
+ "byteorder",
+ "cannyls",
+ "fibers",
+ "fibers_rpc",
+ "fibers_tasque",
+ "frugalos_raft",
+ "futures",
+ "libfrugalos",
+ "prometrics",
+ "protobuf_codec",
+ "raftlog",
+ "rendezvous_hash",
+ "serde",
+ "serde_derive",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "frugalos_core"
 version = "1.0.0"
 dependencies = [
- "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustracing",
+ "rustracing_jaeger",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "trackable",
 ]
 
 [[package]]
 name = "frugalos_mds"
 version = "1.1.2"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frugalos_core 1.0.0",
- "frugalos_raft 1.1.2",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "patricia_tree 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "bytecodec",
+ "byteorder",
+ "cannyls",
+ "fibers",
+ "fibers_global",
+ "fibers_rpc",
+ "fibers_tasque",
+ "frugalos_core",
+ "frugalos_raft",
+ "futures",
+ "libfrugalos",
+ "patricia_tree",
+ "prometrics",
+ "protobuf_codec",
+ "raftlog",
+ "rand 0.5.5",
+ "rustracing",
+ "rustracing_jaeger",
+ "serde",
+ "serde_derive",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "frugalos_raft"
 version = "1.1.2"
 dependencies = [
- "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog_protobuf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32",
+ "atomic_immut",
+ "bytecodec",
+ "byteorder",
+ "cannyls",
+ "fibers",
+ "fibers_global",
+ "fibers_rpc",
+ "futures",
+ "prometrics",
+ "protobuf_codec",
+ "raftlog",
+ "raftlog_protobuf",
+ "rand 0.5.5",
+ "serde",
+ "serde_derive",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "frugalos_segment"
 version = "1.1.2"
 dependencies = [
- "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)",
- "ecpool 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frugalos_core 1.0.0",
- "frugalos_mds 1.1.2",
- "frugalos_raft 1.1.2",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libfrugalos 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32",
+ "byteorder",
+ "cannyls",
+ "cannyls_rpc",
+ "ecpool",
+ "fibers",
+ "fibers_global",
+ "fibers_rpc",
+ "fibers_tasque",
+ "frugalos_core",
+ "frugalos_mds",
+ "frugalos_raft",
+ "futures",
+ "libfrugalos",
+ "prometrics",
+ "raftlog",
+ "rand 0.5.5",
+ "rustracing",
+ "rustracing_jaeger",
+ "serde",
+ "serde_derive",
+ "siphasher",
+ "slog",
+ "trackable",
 ]
 
 [[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "fuchsia-zircon-sys",
 ]
 
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 
 [[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winutil",
 ]
 
 [[package]]
 name = "httpcodec"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235f5e05cc336f97b050fe0d678be8cbe1bd7dfdd54417ec386d7bba92ebf0de"
 dependencies = [
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecodec",
+ "trackable",
 ]
 
 [[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "isatty"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 
 [[package]]
 name = "jemalloc-ctl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e93b0f37e7d735c6b610176d5b1bde8e1621ff3f6f7ac23cdfa4e7f7d0111b5"
 dependencies = [
- "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]
 name = "jemalloc-sys"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "fs_extra",
+ "libc",
 ]
 
 [[package]]
 name = "jemallocator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 dependencies = [
- "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check",
 ]
 
 [[package]]
 name = "lazycell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 
 [[package]]
 name = "libc"
 version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 
 [[package]]
 name = "liberasurecode"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9b4f294bb41a7f5333ab240eb33c71631378e32825d9db11f45e4ed0198325"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "libflate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
 dependencies = [
- "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32",
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
 name = "libfrugalos"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02ca4b1b4f0ba470a1a7f0db9fd7f68d0826e3a298a77a7062ca12724c410e0"
 dependencies = [
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecodec",
+ "fibers",
+ "fibers_rpc",
+ "futures",
+ "libc",
+ "serde",
+ "serde_derive",
+ "trackable",
 ]
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 
 [[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "version_check",
 ]
 
 [[package]]
 name = "mio"
 version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "lazycell",
+ "libc",
+ "log 0.4.5",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
 name = "nbchan"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b1d61edb4e941c69f2a74782b3dc4a388adeab2d8cc1fe29e8ef8d2a7f9760"
 
 [[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "nom"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 
 [[package]]
 name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "patricia_tree"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0266b09b90fffa8b2a2d45ce215d2b2789048294faa39c7e92f65676fd0ba5f4"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "bytecodec",
+ "libc",
+ "trackable",
 ]
 
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "proc-macro2"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "procinfo"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "libc",
+ "nom",
+ "rustc_version",
 ]
 
 [[package]]
 name = "prometrics"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7eb3e65f1053a5d62bd464c71de8e75c25c739cdbcd6e19b527e4d31ea64026"
 dependencies = [
- "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic_immut",
+ "lazy_static 1.1.0",
+ "libc",
+ "procinfo",
+ "trackable",
 ]
 
 [[package]]
 name = "protobuf_codec"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4341aa6631dac24b35b10fd19d3d3ca3eb15e695da103d84e9f0bd6a8a26e25"
 dependencies = [
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecodec",
+ "trackable",
 ]
 
 [[package]]
 name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "raftlog"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94979b0d3bbf241d77634ddf4b6dd79785777abdc032a74f9518de7914b977fb"
 dependencies = [
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "prometrics",
+ "trackable",
 ]
 
 [[package]]
 name = "raftlog_protobuf"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5034e76dce9e6e907d9098b770e849b8494fd0cf669cf3aa479065b45c540a7"
 dependencies = [
- "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecodec",
+ "protobuf_codec",
+ "raftlog",
+ "trackable",
 ]
 
 [[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.0",
+ "rdrand",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "rand"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi",
+ "fuchsia-zircon",
+ "libc",
+ "rand_core 0.2.2",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 
 [[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 
 [[package]]
 name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 dependencies = [
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+ "utf8-ranges",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util",
 ]
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "rendezvous_hash"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57945186414af6d9e4d142e3131471be134c6ad299900021076b3806be9362e5"
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 
 [[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver",
 ]
 
 [[package]]
 name = "rustracing"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65536f02f89c75dd523cc318e7e1d3cb49a32dbc918a798d04d2ab7547125a97"
 dependencies = [
- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace",
+ "rand 0.5.5",
+ "trackable",
 ]
 
 [[package]]
 name = "rustracing_jaeger"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8583585ee130f0e430438ccead5ec49d804805f5b2b67faf1ee0abbe26cd9c1"
 dependencies = [
- "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "thrift_codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hostname",
+ "rand 0.5.5",
+ "rustracing",
+ "thrift_codec",
+ "trackable",
 ]
 
 [[package]]
 name = "ryu"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 
 [[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 
 [[package]]
 name = "serde_derive"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_ignored"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 dependencies = [
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 dependencies = [
- "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 dependencies = [
- "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "slab"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 
 [[package]]
 name = "slog"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
 
 [[package]]
 name = "slog-async"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
 dependencies = [
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog",
+ "take_mut",
+ "thread_local",
 ]
 
 [[package]]
 name = "slog-kvfilter"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae939ed7d169eed9699f4f5cd440f046f5dc5dfc27c19e3cd311619594c175e0"
 dependencies = [
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex",
+ "slog",
 ]
 
 [[package]]
 name = "slog-scope"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053344c94c0e2b22da6305efddb698d7c485809427cf40555dc936085f67a9df"
 dependencies = [
- "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam",
+ "lazy_static 0.2.11",
+ "slog",
 ]
 
 [[package]]
 name = "slog-stdlog"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
 dependencies = [
- "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam",
+ "log 0.3.9",
+ "slog",
+ "slog-scope",
 ]
 
 [[package]]
 name = "slog-term"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
+ "isatty",
+ "slog",
+ "term",
+ "thread_local",
 ]
 
 [[package]]
 name = "sloggers"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1a15430a70a22ce2b066263dc55580a90b6920b837769332d2d0844a445549"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-kvfilter 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
+ "libflate",
+ "regex",
+ "serde",
+ "serde_derive",
+ "slog",
+ "slog-async",
+ "slog-kvfilter",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
+ "trackable",
 ]
 
 [[package]]
 name = "splay_tree"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309dee0d93c0a8f7a852cbd9a86e01e1a94781b64d98d86a191f4af7f095ecc1"
 
 [[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 
 [[package]]
 name = "syn"
 version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tasque"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e455dd8a096f753fe888897a99cee80b88a44096300a6b6ab5c4f5c224a0d0d"
 dependencies = [
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus",
+ "prometrics",
 ]
 
 [[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
 name = "term"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 dependencies = [
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0",
 ]
 
 [[package]]
 name = "thrift_codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb61fb3d0a0af14949f3a6949b2639112e13226647112824f4d081533f9b1a8"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "trackable",
 ]
 
 [[package]]
 name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "trackable"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d96a9d6c49c0fb3620fe8513ada964939e4e5eb017e40936d595e47daf7542d"
 dependencies = [
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "trackable_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_derive",
+ "trackable_derive",
 ]
 
 [[package]]
 name = "trackable_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4062d54dd240bde289717d6b4af18048c3dd552f01a0fd93824f5fc4d2d084"
 dependencies = [
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "url"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
 dependencies = [
- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna",
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "utf8-ranges"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 
 [[package]]
 name = "uuid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 dependencies = [
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5",
 ]
 
 [[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winutil"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6",
 ]
 
 [[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "yaml-rust"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"
 dependencies = [
- "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map",
 ]
-
-[metadata]
-"checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9fcea66a65a49890058406499cca8906e4e9cd1173bfeb272dcd2ac603e4fa"
-"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
-"checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-"checksum bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "599c561412645564bcfaaacf31368ddf074d7350097f1252565aa88680c9c3c2"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adc3889f5a278d46b34e1fb0e6d6619ffc18d84811aedeb50e210dcc96bd3328"
-"checksum cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)" = "<none>"
-"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
-"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-"checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
-"checksum ecpool 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b26a3d6098ac6bf3952357c8dbe386705408069942b35f6c9da5dac5233849"
-"checksum factory 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12035ccde1cff7c507200fd9e7ad0dbceda81d3cf6f68a265974a213d24acfde"
-"checksum fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cce97d737d7eda3d2e8a907892b4c4fdd3857cb6f18b58047645011c5a0b46e7"
-"checksum fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "342af6a6f5bcb2fbd6a08178d7e1816af40ec94d38071eb8abd1ab60b0d44d2b"
-"checksum fibers_http_server 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e4b2f7e9a07ed9e13092fec835e85b7d9c7345ec88263c67b42e046cd930f777"
-"checksum fibers_rpc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "56413f3c95f2a93aaf579d1f549ac4043b8a2ed5f37e7fd5d3d32be58ef88691"
-"checksum fibers_tasque 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ec69910a085e2be9327da6c3c82556b180e8be6d91bc4e0d18b49b4b0fbf32f9"
-"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
-"checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
-"checksum httpcodec 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "235f5e05cc336f97b050fe0d678be8cbe1bd7dfdd54417ec386d7bba92ebf0de"
-"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
-"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e93b0f37e7d735c6b610176d5b1bde8e1621ff3f6f7ac23cdfa4e7f7d0111b5"
-"checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
-"checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum liberasurecode 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b9b4f294bb41a7f5333ab240eb33c71631378e32825d9db11f45e4ed0198325"
-"checksum libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
-"checksum libfrugalos 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d02ca4b1b4f0ba470a1a7f0db9fd7f68d0826e3a298a77a7062ca12724c410e0"
-"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
-"checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum nbchan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "72b1d61edb4e941c69f2a74782b3dc4a388adeab2d8cc1fe29e8ef8d2a7f9760"
-"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
-"checksum patricia_tree 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "0266b09b90fffa8b2a2d45ce215d2b2789048294faa39c7e92f65676fd0ba5f4"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
-"checksum procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
-"checksum prometrics 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7eb3e65f1053a5d62bd464c71de8e75c25c739cdbcd6e19b527e4d31ea64026"
-"checksum protobuf_codec 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e4341aa6631dac24b35b10fd19d3d3ca3eb15e695da103d84e9f0bd6a8a26e25"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum raftlog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94979b0d3bbf241d77634ddf4b6dd79785777abdc032a74f9518de7914b977fb"
-"checksum raftlog_protobuf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5034e76dce9e6e907d9098b770e849b8494fd0cf669cf3aa479065b45c540a7"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
-"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
-"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rendezvous_hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57945186414af6d9e4d142e3131471be134c6ad299900021076b3806be9362e5"
-"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustracing 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65536f02f89c75dd523cc318e7e1d3cb49a32dbc918a798d04d2ab7547125a97"
-"checksum rustracing_jaeger 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d8583585ee130f0e430438ccead5ec49d804805f5b2b67faf1ee0abbe26cd9c1"
-"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
-"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
-"checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
-"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
-"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
-"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-"checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
-"checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
-"checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
-"checksum slog-kvfilter 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae939ed7d169eed9699f4f5cd440f046f5dc5dfc27c19e3cd311619594c175e0"
-"checksum slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "053344c94c0e2b22da6305efddb698d7c485809427cf40555dc936085f67a9df"
-"checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
-"checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
-"checksum sloggers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca1a15430a70a22ce2b066263dc55580a90b6920b837769332d2d0844a445549"
-"checksum splay_tree 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "309dee0d93c0a8f7a852cbd9a86e01e1a94781b64d98d86a191f4af7f095ecc1"
-"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
-"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-"checksum tasque 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e455dd8a096f753fe888897a99cee80b88a44096300a6b6ab5c4f5c224a0d0d"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum thrift_codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb61fb3d0a0af14949f3a6949b2639112e13226647112824f4d081533f9b1a8"
-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum trackable 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "3d96a9d6c49c0fb3620fe8513ada964939e4e5eb017e40936d595e47daf7542d"
-"checksum trackable_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0f4062d54dd240bde289717d6b4af18048c3dd552f01a0fd93824f5fc4d2d084"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
-"checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "cannyls_rpc"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device#9c9e4ccf7775c7dfc198133e3da073f825c6e8f9"
 dependencies = [
  "atomic_immut 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -278,7 +278,7 @@ dependencies = [
  "bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_http_server 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,7 +407,7 @@ dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cannyls_rpc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)",
  "ecpool 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fibers_global 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1315,7 +1315,7 @@ dependencies = [
 "checksum bytecodec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "599c561412645564bcfaaacf31368ddf074d7350097f1252565aa88680c9c3c2"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum cannyls 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adc3889f5a278d46b34e1fb0e6d6619ffc18d84811aedeb50e210dcc96bd3328"
-"checksum cannyls_rpc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "471ec36a5254c4033cb713be738d112b4a80fafcdf65a6d6b3be8ef6f9a32f1e"
+"checksum cannyls_rpc 0.3.0 (git+https://github.com/frugalos/cannyls_rpc?branch=feature/stop-device)" = "<none>"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ trackable = "^0.2.21"
 
 [workspace]
 members = ["frugalos_core", "frugalos_config", "frugalos_mds", "frugalos_raft", "frugalos_segment"]
+
+[patch.crates-io]
+cannyls_rpc = {git = "https://github.com/frugalos/cannyls_rpc", branch = "feature/stop-device"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ atomic_immut = "0.1"
 bytecodec = { version = "0.4", features = ["json_codec"] }
 byteorder = { version = "1", features = ["i128"] }
 cannyls = "0.10"
-cannyls_rpc = "0.3"
+cannyls_rpc = "0.3.1"
 clap = "2"
 fibers = "0.1"
 fibers_http_server = "0.1.12"
@@ -60,6 +60,3 @@ trackable = "^0.2.21"
 
 [workspace]
 members = ["frugalos_core", "frugalos_config", "frugalos_mds", "frugalos_raft", "frugalos_segment"]
-
-[patch.crates-io]
-cannyls_rpc = {git = "https://github.com/frugalos/cannyls_rpc", branch = "feature/stop-device"}

--- a/it/scripts/put_devices.sh
+++ b/it/scripts/put_devices.sh
@@ -13,12 +13,11 @@ SERVERS=$@
 ##
 ## 物理デバイス登録
 ##
-for server in $SERVERS
-do
-    for device in `seq 1 $DEVICES_PER_SERVER`
-    do
+for server in $SERVERS; do
+    for device in $(seq 1 $DEVICES_PER_SERVER); do
         device_id="${server}_${device}"
-        JSON=$(cat <<EOF
+        JSON=$(
+            cat <<EOF
 {"file": {
   "id": "${device_id}",
   "server": "${server}",
@@ -26,7 +25,7 @@ do
   "filepath": "${DISK_DIR_ROOT}/device_${device}.lusf"
 }}
 EOF
-            )
+        )
         curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/${device_id}
     done
 done
@@ -34,34 +33,35 @@ done
 ##
 ## 仮想デバイス登録
 ##
-for server in $SERVERS
-do
+for server in $SERVERS; do
     CHILDREN=""
-    for device in `seq 1 $DEVICES_PER_SERVER`
-    do
+    for device in $(seq 1 $DEVICES_PER_SERVER); do
         device_id="${server}_${device}"
-        if [ "${CHILDREN}" != "" ]
-        then
+        if [ "${CHILDREN}" != "" ]; then
             CHILDREN="${CHILDREN},"
         fi
         CHILDREN="${CHILDREN} \"${device_id}\""
     done
-    JSON=$(cat <<EOF
+    JSON=$(
+        cat <<EOF
 {"virtual": {
   "id": "${server}",
   "children": [${CHILDREN}]
 }}
 EOF
-            )
+    )
     curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/${server}
 done
 
-CHILDREN=`echo $SERVERS | sed -e 's/ /","/g'`
-JSON=$(cat <<EOF
+CHILDREN=$(echo $SERVERS | sed -e 's/ /","/g')
+JSON=$(
+    cat <<EOF
 {"virtual": {
   "id": "rack",
   "children": ["${CHILDREN}"]
 }}
 EOF
-    )
+)
 curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/store01
+
+set +x

--- a/it/scripts/put_devices.sh
+++ b/it/scripts/put_devices.sh
@@ -13,11 +13,12 @@ SERVERS=$@
 ##
 ## 物理デバイス登録
 ##
-for server in $SERVERS; do
-    for device in $(seq 1 $DEVICES_PER_SERVER); do
+for server in $SERVERS
+do
+    for device in `seq 1 $DEVICES_PER_SERVER`
+    do
         device_id="${server}_${device}"
-        JSON=$(
-            cat <<EOF
+        JSON=$(cat <<EOF
 {"file": {
   "id": "${device_id}",
   "server": "${server}",
@@ -25,7 +26,7 @@ for server in $SERVERS; do
   "filepath": "${DISK_DIR_ROOT}/device_${device}.lusf"
 }}
 EOF
-        )
+            )
         curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/${device_id}
     done
 done
@@ -33,35 +34,34 @@ done
 ##
 ## 仮想デバイス登録
 ##
-for server in $SERVERS; do
+for server in $SERVERS
+do
     CHILDREN=""
-    for device in $(seq 1 $DEVICES_PER_SERVER); do
+    for device in `seq 1 $DEVICES_PER_SERVER`
+    do
         device_id="${server}_${device}"
-        if [ "${CHILDREN}" != "" ]; then
+        if [ "${CHILDREN}" != "" ]
+        then
             CHILDREN="${CHILDREN},"
         fi
         CHILDREN="${CHILDREN} \"${device_id}\""
     done
-    JSON=$(
-        cat <<EOF
+    JSON=$(cat <<EOF
 {"virtual": {
   "id": "${server}",
   "children": [${CHILDREN}]
 }}
 EOF
-    )
+            )
     curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/${server}
 done
 
-CHILDREN=$(echo $SERVERS | sed -e 's/ /","/g')
-JSON=$(
-    cat <<EOF
+CHILDREN=`echo $SERVERS | sed -e 's/ /","/g'`
+JSON=$(cat <<EOF
 {"virtual": {
   "id": "rack",
   "children": ["${CHILDREN}"]
 }}
 EOF
-)
+    )
 curl -f -XPUT -d "$JSON" http://$API_HOST/v1/devices/store01
-
-set +x

--- a/it/testsuites/all.sh
+++ b/it/testsuites/all.sh
@@ -5,3 +5,4 @@ set -eux
 it/testsuites/basic.sh
 it/testsuites/down.sh
 it/testsuites/repair.sh
+it/testsuites/device.sh

--- a/it/testsuites/device.sh
+++ b/it/testsuites/device.sh
@@ -1,0 +1,93 @@
+#! /bin/bash
+
+set -eux
+
+source $(
+    cd $(dirname $0)
+    pwd
+)/common.sh
+
+set +x
+
+CLUSTER=three-nodes
+# CLUSTER=nine-nodes
+
+#
+# Cleanups previous garbages
+#
+docker-compose -f it/clusters/${CLUSTER}.yml down
+sudo rm -rf /tmp/frugalos_it/
+
+#
+# Setups cluster
+#
+docker-compose -f it/clusters/${CLUSTER}.yml up -d
+mkdir -p ${WORK_DIR}
+sudo chmod 777 ${WORK_DIR}
+sleep 1
+curl -f http://frugalos01/v1/servers | tee $WORK_DIR/servers.json
+SERVERS=$(jq 'map(.id) | .[]' /tmp/frugalos_it/servers.json | sed -e 's/"//g')
+
+#
+# Setups devices
+#
+it/scripts/put_devices.sh 1 $SERVERS
+
+#
+# Setups buckets
+#
+it/scripts/put_buckets.sh 1 2
+curl -s http://frugalos01/v1/buckets | jq '.[] | .id'
+
+#
+# Start
+#
+
+#
+# Check if state is started
+#
+function check_state() {
+    curl -fs http://frugalos01/v1/devices/frugalos01_1/state | jq '.state'
+}
+STATE=$(check_state)
+
+if [ ${STATE} != '"started"' ]; then
+    echo "STATE should be started"
+    exit 1
+fi
+
+#
+# Stop the device
+#
+curl -fs http://frugalos01/v1/devices/frugalos01_1/state -XPUT -d '{"state":"stopped"}' >/dev/null
+
+STATE=$(check_state)
+
+if [ ${STATE} != '"stopped"' ]; then
+    echo "STATE should be stopped"
+    exit 1
+fi
+
+#
+# Even though frugalos01_1 is stopped, PUT requests should not fail.
+#
+it/scripts/gen_put_requests.sh frugalos01 replicated 1 1000 $WORK_DIR/req.json
+EXIT_STATUS=1
+#
+# Try to put until all 1000 requests succeed.
+#
+echo "Trying to put 1000 objects..." 1>&2
+for i in $(seq 1 10); do
+    STATUS=$(hb run -i $WORK_DIR/req.json | hb summary | jq '.status')
+    echo ${i} status=${STATUS} 1>&2
+    if [ $(echo ${STATUS} | jq '."200"') = 1000 ]; then
+        EXIT_STATUS=0
+        break
+    fi
+    sleep 5
+done
+
+if [ ${EXIT_STATUS} -ne 0 ]; then
+    echo "Failed to put 1000 objects." 1>&2
+    exit ${EXIT_STATUS}
+fi

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -214,7 +214,7 @@ struct DeviceState {
     state: RunningState,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Copy, Clone)]
 #[serde(rename_all = "lowercase")]
 enum RunningState {
     Started,
@@ -228,7 +228,6 @@ impl HandleRequest for PutDeviceState {
 
     type ReqBody = DeviceState;
     type ResBody = HttpResult<DeviceState>;
-    // type ResBody = HttpResult<()>;
     type Decoder = BodyDecoder<JsonDecoder<Self::ReqBody>>;
     type Encoder = BodyEncoder<JsonEncoder<Self::ResBody>>;
     type Reply = Reply<Self::ResBody>;
@@ -248,9 +247,12 @@ impl HandleRequest for PutDeviceState {
                 };
                 futures::future::ok((status, body))
             })
-            .and_then(move |(status, body)| match body {
-                Err(e) => Either::A(futures::future::ok((status, Err(e)))),
-                Ok(device) => {
+            .and_then(move |(status, body)| match (body, device_state.state) {
+                (Err(e), _) => Either::A(futures::future::ok((status, Err(e)))),
+                (Ok(_device), RunningState::Started) => {
+                    Either::A(futures::future::ok((status, Ok(device_state))))
+                }
+                (Ok(device), RunningState::Stopped) => {
                     let device_seqno = device.seqno();
                     let device_id = DeviceId::new(device.id());
                     let future =

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -1,7 +1,9 @@
 use bytecodec::json_codec::{JsonDecoder, JsonEncoder};
 use bytecodec::null::NullDecoder;
+use cannyls_rpc::DeviceId;
 use fibers_http_server::{HandleRequest, Reply, Req, ServerBuilder as HttpServerBuilder, Status};
 use fibers_rpc::client::ClientServiceHandle as RpcServiceHandle;
+use futures::future::Either;
 use futures::Future;
 use httpcodec::{BodyDecoder, BodyEncoder};
 use libfrugalos::client::config::Client as ConfigRpcClient;
@@ -11,6 +13,7 @@ use libfrugalos::entity::server::{Server, ServerSummary};
 use std::net::SocketAddr;
 use url::Url;
 
+use crate::daemon::FrugalosDaemonHandle;
 use crate::http::{make_json_response, not_found, HttpResult};
 use crate::{Error, Result};
 
@@ -18,12 +21,18 @@ use crate::{Error, Result};
 pub struct ConfigServer {
     rpc_service: RpcServiceHandle,
     local_addr: SocketAddr,
+    daemon_handle: FrugalosDaemonHandle,
 }
 impl ConfigServer {
-    pub fn new(rpc_service: RpcServiceHandle, local_addr: SocketAddr) -> Self {
+    pub fn new(
+        rpc_service: RpcServiceHandle,
+        local_addr: SocketAddr,
+        daemon_handle: FrugalosDaemonHandle,
+    ) -> Self {
         ConfigServer {
             rpc_service,
             local_addr,
+            daemon_handle,
         }
     }
     pub fn register(self, builder: &mut HttpServerBuilder) -> Result<()> {
@@ -34,6 +43,7 @@ impl ConfigServer {
         track!(builder.add_handler(ListDevices(self.clone())))?;
         track!(builder.add_handler(PutDevice(self.clone())))?;
         track!(builder.add_handler(GetDevice(self.clone())))?;
+        track!(builder.add_handler(PutDeviceState(self.clone())))?;
 
         track!(builder.add_handler(ListBuckets(self.clone())))?;
         track!(builder.add_handler(PutBucket(self.clone())))?;
@@ -195,6 +205,96 @@ impl HandleRequest for GetDevice {
             };
             Ok(make_json_response(status, body))
         });
+        Box::new(future)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct DeviceState {
+    state: RunningState,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RunningState {
+    Started,
+    Stopped,
+}
+
+struct PutDeviceState(ConfigServer);
+impl HandleRequest for PutDeviceState {
+    const METHOD: &'static str = "PUT";
+    const PATH: &'static str = "/v1/devices/*/state";
+
+    type ReqBody = DeviceState;
+    type ResBody = HttpResult<DeviceState>;
+    // type ResBody = HttpResult<()>;
+    type Decoder = BodyDecoder<JsonDecoder<Self::ReqBody>>;
+    type Encoder = BodyEncoder<JsonEncoder<Self::ResBody>>;
+    type Reply = Reply<Self::ResBody>;
+
+    fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
+        let device_id = get_id(&req.url());
+        let device_state = req.into_body();
+        let client = self.0.client();
+        let daemon_handle = self.0.daemon_handle.clone();
+        let future = client
+            .get_device(device_id)
+            .then(move |result| {
+                let (status, body) = match track!(result) {
+                    Err(e) => (Status::InternalServerError, Err(Error::from(e))),
+                    Ok(None) => (Status::NotFound, Err(track!(not_found()))),
+                    Ok(Some(v)) => (Status::Ok, Ok(v)),
+                };
+                futures::future::ok((status, body))
+            })
+            .and_then(move |(status, body)| match body {
+                Err(e) => Either::A(futures::future::ok((status, Err(e)))),
+                Ok(device) => {
+                    let device_seqno = device.seqno();
+                    let device_id = DeviceId::new(device.id());
+                    let future =
+                        daemon_handle
+                            .stop_device(device_seqno, device_id)
+                            .map(move |result| {
+                                if result {
+                                    (status, Ok(device_state))
+                                } else {
+                                    (Status::NotFound, Err(track!(not_found())))
+                                }
+                            });
+                    Either::B(future)
+                }
+            })
+            .then(move |result| {
+                let result = match result {
+                    Ok((status, body)) => make_json_response(status, body),
+                    Err(e) => make_json_response(Status::InternalServerError, Err(e)),
+                };
+                Ok(result)
+            });
+        Box::new(future)
+    }
+}
+
+struct GetDeviceState(ConfigServer);
+impl HandleRequest for GetDeviceState {
+    const METHOD: &'static str = "GET";
+    const PATH: &'static str = "/v1/devices/*/state";
+
+    type ReqBody = ();
+    type ResBody = HttpResult<DeviceState>;
+    type Decoder = BodyDecoder<NullDecoder>;
+    type Encoder = BodyEncoder<JsonEncoder<Self::ResBody>>;
+    type Reply = Reply<Self::ResBody>;
+
+    fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
+        let _device_id = get_id(&req.url());
+        let device_state = DeviceState {
+            state: RunningState::Started,
+        };
+        // TODO
+        let future = futures::future::ok(make_json_response(Status::Ok, Ok(device_state)));
         Box::new(future)
     }
 }

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -43,6 +43,7 @@ impl ConfigServer {
         track!(builder.add_handler(ListDevices(self.clone())))?;
         track!(builder.add_handler(PutDevice(self.clone())))?;
         track!(builder.add_handler(GetDevice(self.clone())))?;
+        track!(builder.add_handler(GetDeviceState(self.clone())))?;
         track!(builder.add_handler(PutDeviceState(self.clone())))?;
 
         track!(builder.add_handler(ListBuckets(self.clone())))?;
@@ -291,12 +292,50 @@ impl HandleRequest for GetDeviceState {
     type Reply = Reply<Self::ResBody>;
 
     fn handle_request(&self, req: Req<Self::ReqBody>) -> Self::Reply {
-        let _device_id = get_id(&req.url());
-        let device_state = DeviceState {
-            state: RunningState::Started,
-        };
+        let device_id = get_id(&req.url());
+        let client = self.0.client();
+        let daemon_handle = self.0.daemon_handle.clone();
         // TODO
-        let future = futures::future::ok(make_json_response(Status::Ok, Ok(device_state)));
+        let future = client
+            .get_device(device_id)
+            .then(move |result| {
+                let (status, body) = match track!(result) {
+                    Err(e) => (Status::InternalServerError, Err(Error::from(e))),
+                    Ok(None) => (Status::NotFound, Err(track!(not_found()))),
+                    Ok(Some(v)) => (Status::Ok, Ok(v)),
+                };
+                futures::future::ok((status, body))
+            })
+            .and_then(move |(status, body)| match body {
+                Err(e) => Either::A(futures::future::ok((status, Err(e)))),
+                Ok(device) => {
+                    let device_seqno = device.seqno();
+                    let device_id = DeviceId::new(device.id());
+                    let future = daemon_handle.get_device_state(device_seqno, device_id).map(
+                        move |result| {
+                            let device_state = if result {
+                                DeviceState {
+                                    state: RunningState::Started,
+                                }
+                            } else {
+                                DeviceState {
+                                    state: RunningState::Stopped,
+                                }
+                            };
+                            (status, Ok(device_state))
+                        },
+                    );
+                    Either::B(future)
+                }
+            })
+            .then(move |result| {
+                let result = match result {
+                    Ok((status, body)) => make_json_response(status, body),
+                    Err(e) => make_json_response(Status::InternalServerError, Err(e)),
+                };
+                Ok(result)
+            });
+
         Box::new(future)
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -224,6 +224,14 @@ impl DaemonRunner {
                 let result = self.service.stop_device(device_seqno, &device_id);
                 reply.exit(Ok(result))
             }
+            DaemonCommand::GetDeviceState {
+                device_seqno,
+                device_id,
+                reply,
+            } => {
+                let result = self.service.get_device_state(device_seqno, &device_id);
+                reply.exit(Ok(result))
+            }
         }
     }
 }
@@ -290,6 +298,23 @@ impl FrugalosDaemonHandle {
         let _ = self.command_tx.send(command);
         StopDevice(reply_rx)
     }
+
+    /// デバイスの状態を要求する
+    pub fn get_device_state(
+        &self,
+        device_seqno: u32,
+        device_id: DeviceId,
+    ) -> impl Future<Item = bool, Error = Error> {
+        let (reply_tx, reply_rx) = oneshot::monitor();
+        // TODO
+        let command = DaemonCommand::GetDeviceState {
+            device_seqno,
+            device_id,
+            reply: reply_tx,
+        };
+        let _ = self.command_tx.send(command);
+        StopDevice(reply_rx)
+    }
 }
 
 #[derive(Debug)]
@@ -302,6 +327,11 @@ enum DaemonCommand {
         bucket_seqno: u32,
     },
     StopDevice {
+        device_seqno: u32,
+        device_id: DeviceId,
+        reply: oneshot::Monitored<bool, Error>,
+    },
+    GetDeviceState {
         device_seqno: u32,
         device_id: DeviceId,
         reply: oneshot::Monitored<bool, Error>,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -21,6 +21,7 @@ use std::process::Command;
 use trackable::error::ErrorKindExt;
 
 use crate::config_server::ConfigServer;
+use crate::device::DeviceState;
 use crate::recovery::prepare_recovery;
 use crate::rpc_server::RpcServer;
 use crate::server::{spawn_report_spans_thread, Server};
@@ -310,7 +311,7 @@ impl FrugalosDaemonHandle {
         &self,
         device_seqno: u32,
         device_id: DeviceId,
-    ) -> impl Future<Item = bool, Error = Error> {
+    ) -> impl Future<Item = DeviceState, Error = Error> {
         let (reply_tx, reply_rx) = oneshot::monitor();
         let command = DaemonCommand::GetDeviceState {
             device_seqno,
@@ -345,7 +346,7 @@ enum DaemonCommand {
     GetDeviceState {
         device_seqno: u32,
         device_id: DeviceId,
-        reply: oneshot::Monitored<bool, Error>,
+        reply: oneshot::Monitored<DeviceState, Error>,
     },
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,11 @@
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DeviceState {
+    pub(crate) state: RunningState,
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum RunningState {
+    Started,
+    Stopped,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod bucket;
 mod client;
 mod codec;
 mod config_server;
+mod device;
 mod error;
 mod http;
 mod many_objects;

--- a/src/service.rs
+++ b/src/service.rs
@@ -32,6 +32,7 @@ use trackable::error::ErrorKindExt;
 
 use crate::bucket::Bucket;
 use crate::client::FrugalosClient;
+use crate::device::{DeviceState, RunningState};
 use crate::recovery::RecoveryRequest;
 use crate::{DeviceBuildingConfig, Error, ErrorKind, FrugalosServiceConfig, Result};
 use frugalos_core::lump::{LUMP_ID_NAMESPACE_OBJECT, LUMP_ID_NAMESPACE_RAFTLOG};
@@ -148,16 +149,25 @@ where
         false
     }
     // 単にデバイスのデータを取得するだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
-    pub fn get_device_state(&mut self, device_seqno: u32, device_id: &DeviceId) -> bool {
+    pub fn get_device_state(&mut self, device_seqno: u32, device_id: &DeviceId) -> DeviceState {
         info!(
             self.logger,
             "Getting device state";
             "device_seqno" => device_seqno,
             "device_id" => device_id.as_str(),
         );
-        self.frugalos_segment_service
+        let running_state = if self
+            .frugalos_segment_service
             .device_registry_mut()
             .is_device_running(device_id)
+        {
+            RunningState::Started
+        } else {
+            RunningState::Stopped
+        };
+        DeviceState {
+            state: running_state,
+        }
     }
     pub fn take_snapshot(&mut self) {
         self.frugalos_segment_service.take_snapshot();

--- a/src/service.rs
+++ b/src/service.rs
@@ -147,6 +147,18 @@ where
         );
         false
     }
+    /// 単にデバイスのデータを取得するだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
+    pub fn get_device_state(&mut self, device_seqno: u32, device_id: &DeviceId) -> bool {
+        info!(
+            self.logger,
+            "Getting device state";
+            "device_seqno" => device_seqno,
+            "device_id" => device_id.as_str(),
+        );
+        self.frugalos_segment_service
+            .device_registry_mut()
+            .is_device_running(device_id)
+    }
     pub fn take_snapshot(&mut self) {
         self.frugalos_segment_service.take_snapshot();
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -124,6 +124,29 @@ where
     pub fn stop(&mut self) {
         self.frugalos_segment_service.stop();
     }
+    /// 単に止めるためだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
+    pub fn stop_device(&mut self, device_seqno: u32, device_id: &DeviceId) -> bool {
+        let existed = self
+            .frugalos_segment_service
+            .device_registry_mut()
+            .stop_device(device_id);
+        if existed {
+            info!(
+                self.logger,
+                "Stopping device";
+                "device_seqno" => device_seqno,
+                "device_id" => device_id.as_str(),
+            );
+            return true;
+        }
+        info!(
+            self.logger,
+            "Device not found";
+            "device_seqno" => device_seqno,
+            "device_id" => device_id.as_str(),
+        );
+        false
+    }
     pub fn take_snapshot(&mut self) {
         self.frugalos_segment_service.take_snapshot();
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -124,7 +124,7 @@ where
     pub fn stop(&mut self) {
         self.frugalos_segment_service.stop();
     }
-    /// 単に止めるためだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
+    // 単に止めるためだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
     pub fn stop_device(&mut self, device_seqno: u32, device_id: &DeviceId) -> bool {
         let existed = self
             .frugalos_segment_service
@@ -147,7 +147,7 @@ where
         );
         false
     }
-    /// 単にデバイスのデータを取得するだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
+    // 単にデバイスのデータを取得するだけなら device_seqno は不要だが、ログ出力のために受け取っておく。
     pub fn get_device_state(&mut self, device_seqno: u32, device_id: &DeviceId) -> bool {
         info!(
             self.logger,


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
`/v1/devices/:device_id/state` に以下のような JSON を PUT することで、指定されたデバイス ID を持つデバイスを落とせるようにする。
```
{"state":"stopped"}
```

制約は以下の通り:
- 物理デバイスしか落とせない。
- リクエストの送り先が保持するデバイスしか落とせない。

また、`GET /v1/devices/:device_id/state` が、指定されたデバイス ID を持つデバイスが現在動作しているかを返すようにする。
レスポンスは以下のうちどちらか:
```
{"state":"started"} # 動いている
{"state":"stopped"} # 止まっている
```

### Purpose
デバイスを外部から手動で落とせるようにする。


#### リクエストの流れ
デバイス停止・デバイスの情報取得リクエストの処理の流れ:
```
config_server

|
V

daemon

|
V

service

 - Service::stop_device, Service::get_device_state

|
V

frugalos_segment/service.rs
Service
stop_device, get_device_state

|
V

cannyls_rpc/DeviceRegistry
stop_device, is_device_running

|
V

cannyls::device::Device::stop (no need of change)
```

#### 未解決事項
デバイスを落とす時に MDS node が CRIT エラーを出して止まる。これは後の PR で対応する予定。

依存 PR: https://github.com/frugalos/cannyls/pull/48

## How to test this PR

`scripts/setup_debug_cluster.sh` で起動できるローカルクラスタを起動し、以下を実行する:
```
curl localhost:3100/v1/devices/live_archive_chunk/state
```
この状態では (まだデバイスを停止していないため) `{"state":"started"}` が返る。その後、以下を実行する:
```
curl -XPUT localhost:3100/v1/devices/live_archive_chunk/state -d '{"state":"stopped"}'
```

その後、以下を実行すると、`{"state":"stopped"}` が返る。
```
curl localhost:3100/v1/devices/live_archive_chunk/state
```

## 注記事項
cargo のバージョンアップに伴って `Cargo.lock` のフォーマットが変わっている。おそらく https://github.com/rust-lang/cargo/pull/7579 の変更が入ったことによるものである。本来別の PR として分けるべきであるが、それによって起こるであろう `Cargo.lock` のコンフリクトを解消する手間を避けるためにこのままにする。

## TODOs
- [x] cannyls_rpc 0.3.1 を取り込む

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
