### PR TITLE
Use the latest version of rust docker image

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,5 +1,5 @@
 # STAGE-1: Build frugalos binary
-FROM rust:1.38.0-slim
+FROM rust:slim
 
 ARG FRUGALOS_VERSION
 

--- a/docker/hub/publish.sh
+++ b/docker/hub/publish.sh
@@ -8,5 +8,6 @@ set -eux
 
 FRUGALOS_VERSION=$1
 
+docker pull rust:slim
 docker build --build-arg FRUGALOS_VERSION=$FRUGALOS_VERSION -t frugalos/frugalos:${FRUGALOS_VERSION} .
 docker push frugalos/frugalos:${FRUGALOS_VERSION}


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

docker hub への publish 時にその時点での最新の `rust:slim` を利用するようになる。

### Purpose

docker hub への publish 時に rust のバージョンが古くビルドに失敗する問題を避けるため。

## How to test this PR

N/A

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
