### PR TITLE
Change frugalos-build base-image from ringo/scientific:7.2 to centos:7

### DIFF
--- a/docker/frugalos-build/Dockerfile
+++ b/docker/frugalos-build/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## FrugalOSビルド用のベースイメージ
 ##
-FROM ringo/scientific:7.2
+FROM centos:7.8.2003
 
 ##
 ## yumパッケージ群をインストール


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

### Purpose

## How to test this PR

```
$ docker build --no-cache -t frugalos_build_binary --build-arg git_ref=release-1.2.0 docker/frugalos-build
```

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
