### PR TITLE
Update linked-hash-map (0.5.1 -> 0.5.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior
バグが修正される

### Purpose
https://github.com/mehcode/config-rs/issues/158 周辺で、linked-hash-map に UB が見つかったという話があった。
現行の stable rustc (rustc 1.49.0) で frugalos を起動すると以下のようなエラーが出て起動が中断される。
```
thread 'main' panicked at 'attempted to leave type `linked_hash_map::Node<value::Value, value::Value>` uninitialized, which is invalid', /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/mem/mod.rs:659:9
```

https://github.com/contain-rs/linked-hash-map/pull/100 などの一連の PR で修正されており、0.5.1 -> 0.5.4 へと更新すればこのバグは発現しなくなる。



## How to test this PR
`./scripts/setup_debug_cluster.sh` が正しくクラスタを起動することを確かめる。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.
